### PR TITLE
Remove github jobs API - it was shutdown in 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,968 +4,1058 @@ Please note a passing build status indicates all listed APIs are available since
 
 ## Index
 
-* [Animals](#animals)
-* [Anime](#anime)
-* [Anti-Malware](#anti-malware)
-* [Art & Design](#art--design)
-* [Books](#books)
-* [Business](#business)
-* [Calendar](#calendar)
-* [Cloud Storage & File Sharing](#cloud-storage--file-sharing)
-* [Continuous Integration](#continuous-integration)
-* [Cryptocurrency](#cryptocurrency)
-* [Currency Exchange](#currency-exchange)
-* [Data Validation](#data-validation)
-* [Development](#development)
-* [Dictionaries](#dictionaries)
-* [Documents & Productivity](#documents--productivity)
-* [Environment](#environment)
-* [Events](#events)
-* [Finance](#finance)
-* [Food & Drink](#food--drink)
-* [Fraud Prevention](#fraud-prevention)
-* [Games & Comics](#games--comics)
-* [Geocoding](#geocoding)
-* [Government](#government)
-* [Health](#health)
-* [Jobs](#jobs)
-* [Machine Learning](#machine-learning)
-* [Music](#music)
-* [News](#news)
-* [Open Data](#open-data)
-* [Open Source Projects](#open-source-projects)
-* [Patent](#patent)
-* [Personality](#personality)
-* [Photography](#photography)
-* [Science & Math](#science--math)
-* [Security](#security)
-* [Shopping](#shopping)
-* [Social](#social)
-* [Sports & Fitness](#sports--fitness)
-* [Test Data](#test-data)
-* [Text Analysis](#text-analysis)
-* [Tracking](#tracking)
-* [Transportation](#transportation)
-* [URL Shorteners](#url-shorteners)
-* [Vehicle](#vehicle)
-* [Video](#video)
-* [Weather](#weather)
+- [Animals](#animals)
+- [Anime](#anime)
+- [Anti-Malware](#anti-malware)
+- [Art & Design](#art--design)
+- [Books](#books)
+- [Business](#business)
+- [Calendar](#calendar)
+- [Cloud Storage & File Sharing](#cloud-storage--file-sharing)
+- [Continuous Integration](#continuous-integration)
+- [Cryptocurrency](#cryptocurrency)
+- [Currency Exchange](#currency-exchange)
+- [Data Validation](#data-validation)
+- [Development](#development)
+- [Dictionaries](#dictionaries)
+- [Documents & Productivity](#documents--productivity)
+- [Environment](#environment)
+- [Events](#events)
+- [Finance](#finance)
+- [Food & Drink](#food--drink)
+- [Fraud Prevention](#fraud-prevention)
+- [Games & Comics](#games--comics)
+- [Geocoding](#geocoding)
+- [Government](#government)
+- [Health](#health)
+- [Jobs](#jobs)
+- [Machine Learning](#machine-learning)
+- [Music](#music)
+- [News](#news)
+- [Open Data](#open-data)
+- [Open Source Projects](#open-source-projects)
+- [Patent](#patent)
+- [Personality](#personality)
+- [Photography](#photography)
+- [Science & Math](#science--math)
+- [Security](#security)
+- [Shopping](#shopping)
+- [Social](#social)
+- [Sports & Fitness](#sports--fitness)
+- [Test Data](#test-data)
+- [Text Analysis](#text-analysis)
+- [Tracking](#tracking)
+- [Transportation](#transportation)
+- [URL Shorteners](#url-shorteners)
+- [Vehicle](#vehicle)
+- [Video](#video)
+- [Weather](#weather)
 
 ### Animals
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Cat Facts](https://alexwohlbruck.github.io/cat-facts/) | Daily cat facts | No | Yes | No |
-| [Cats](https://docs.thecatapi.com/) | Pictures of cats from Tumblr | `apiKey` | Yes | Unknown |
-| [Dogs](https://dog.ceo/dog-api/) | Based on the Stanford Dogs Dataset | No | Yes | Yes |
-| [HTTPCat](https://http.cat/) | Cat for every HTTP Status | No | Yes | Unknown |
-| [IUCN](http://apiv3.iucnredlist.org/api/v3/docs) | IUCN Red List of Threatened Species | `apiKey` | No | Unknown |
-| [Movebank](https://github.com/movebank/movebank-api-doc) | Movement and Migration data of animals | No | Yes | Unknown |
-| [Petfinder](https://www.petfinder.com/developers/v2/docs/) | Adoption | `OAuth` | Yes | Yes |
-| [PlaceGOAT](https://placegoat.com/) | Placeholder goat images | No | Yes | Unknown |
-| [RandomCat](https://aws.random.cat/meow) | Random pictures of cats | No | Yes | Yes |
-| [RandomDog](https://random.dog/woof.json) | Random pictures of dogs | No | Yes | Yes |
-| [RandomFox](https://randomfox.ca/floof/) | Random pictures of foxes | No | Yes | No |
-| [RescueGroups](https://userguide.rescuegroups.org/display/APIDG/API+Developers+Guide+Home) | Adoption | No | Yes | Unknown |
-| [Shibe.Online](http://shibe.online/) | Random pictures of Shibu Inu, cats or birds | No | Yes | Yes |
+
+| API                                                                                        | Description                                 | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------------------------ | ------------------------------------------- | -------- | ----- | ------- |
+| [Cat Facts](https://alexwohlbruck.github.io/cat-facts/)                                    | Daily cat facts                             | No       | Yes   | No      |
+| [Cats](https://docs.thecatapi.com/)                                                        | Pictures of cats from Tumblr                | `apiKey` | Yes   | Unknown |
+| [Dogs](https://dog.ceo/dog-api/)                                                           | Based on the Stanford Dogs Dataset          | No       | Yes   | Yes     |
+| [HTTPCat](https://http.cat/)                                                               | Cat for every HTTP Status                   | No       | Yes   | Unknown |
+| [IUCN](http://apiv3.iucnredlist.org/api/v3/docs)                                           | IUCN Red List of Threatened Species         | `apiKey` | No    | Unknown |
+| [Movebank](https://github.com/movebank/movebank-api-doc)                                   | Movement and Migration data of animals      | No       | Yes   | Unknown |
+| [Petfinder](https://www.petfinder.com/developers/v2/docs/)                                 | Adoption                                    | `OAuth`  | Yes   | Yes     |
+| [PlaceGOAT](https://placegoat.com/)                                                        | Placeholder goat images                     | No       | Yes   | Unknown |
+| [RandomCat](https://aws.random.cat/meow)                                                   | Random pictures of cats                     | No       | Yes   | Yes     |
+| [RandomDog](https://random.dog/woof.json)                                                  | Random pictures of dogs                     | No       | Yes   | Yes     |
+| [RandomFox](https://randomfox.ca/floof/)                                                   | Random pictures of foxes                    | No       | Yes   | No      |
+| [RescueGroups](https://userguide.rescuegroups.org/display/APIDG/API+Developers+Guide+Home) | Adoption                                    | No       | Yes   | Unknown |
+| [Shibe.Online](http://shibe.online/)                                                       | Random pictures of Shibu Inu, cats or birds | No       | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
+
 ### Anime
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [AniList](https://github.com/AniList/ApiV2-GraphQL-Docs) | Anime discovery & tracking | `OAuth` | Yes | Unknown |
-| [AnimeNewsNetwork](https://www.animenewsnetwork.com/encyclopedia/api.php) | Anime industry news | No | Yes | Yes |
-| [Jikan](https://jikan.moe) | Unofficial MyAnimeList API | No | Yes | Yes |
-| [Kitsu](http://docs.kitsu.apiary.io/) | Anime discovery platform | `OAuth` | Yes | Unknown |
-| [Studio Ghibli](https://ghibliapi.herokuapp.com) | Resources from Studio Ghibli films | No | Yes | Unknown |
+
+| API                                                                       | Description                        | Auth    | HTTPS | CORS    |
+| ------------------------------------------------------------------------- | ---------------------------------- | ------- | ----- | ------- |
+| [AniList](https://github.com/AniList/ApiV2-GraphQL-Docs)                  | Anime discovery & tracking         | `OAuth` | Yes   | Unknown |
+| [AnimeNewsNetwork](https://www.animenewsnetwork.com/encyclopedia/api.php) | Anime industry news                | No      | Yes   | Yes     |
+| [Jikan](https://jikan.moe)                                                | Unofficial MyAnimeList API         | No      | Yes   | Yes     |
+| [Kitsu](http://docs.kitsu.apiary.io/)                                     | Anime discovery platform           | `OAuth` | Yes   | Unknown |
+| [Studio Ghibli](https://ghibliapi.herokuapp.com)                          | Resources from Studio Ghibli films | No      | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Anti-Malware
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [AbuseIPDB](https://docs.abuseipdb.com/) | IP/domain/URL reputation | `apiKey` | Yes | Unknown |
-| [AlienVault Open Threat Exchange (OTX)](https://otx.alienvault.com/api/) | IP/domain/URL reputation | `apiKey` | Yes | Unknown |
-| [Google Safe Browsing](https://developers.google.com/safe-browsing/) | Google Link/Domain Flagging | `apiKey` | Yes | Unknown |
-| [Metacert](https://metacert.com/) | Metacert Link Flagging | `apiKey` | Yes | Unknown |
-| [VirusTotal](https://www.virustotal.com/en/documentation/public-api/) | VirusTotal File/URL Analysis | `apiKey` | Yes | Unknown |
-| [Web Of Trust (WOT)](https://www.mywot.com/en/API) | Website reputation | `apiKey` | Yes | Unknown |
+
+| API                                                                      | Description                  | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------ | ---------------------------- | -------- | ----- | ------- |
+| [AbuseIPDB](https://docs.abuseipdb.com/)                                 | IP/domain/URL reputation     | `apiKey` | Yes   | Unknown |
+| [AlienVault Open Threat Exchange (OTX)](https://otx.alienvault.com/api/) | IP/domain/URL reputation     | `apiKey` | Yes   | Unknown |
+| [Google Safe Browsing](https://developers.google.com/safe-browsing/)     | Google Link/Domain Flagging  | `apiKey` | Yes   | Unknown |
+| [Metacert](https://metacert.com/)                                        | Metacert Link Flagging       | `apiKey` | Yes   | Unknown |
+| [VirusTotal](https://www.virustotal.com/en/documentation/public-api/)    | VirusTotal File/URL Analysis | `apiKey` | Yes   | Unknown |
+| [Web Of Trust (WOT)](https://www.mywot.com/en/API)                       | Website reputation           | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Art & Design
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Behance](https://www.behance.net/dev) | Design | `apiKey` | Yes | Unknown |
-| [Cooper Hewitt](https://collection.cooperhewitt.org/api) | Smithsonian Design Museum | `apiKey` | Yes | Unknown |
-| [Dribbble](http://developer.dribbble.com/v2/) | Design | `OAuth` | No | Unknown |
-| [Harvard Art Museums](https://github.com/harvardartmuseums/api-docs) | Art | `apiKey` | No | Unknown |
-| [Iconfinder](https://developer.iconfinder.com) | Icons | `apiKey` | Yes | Unknown |
-| [Icons8](http://docs.icons8.apiary.io/#reference/0/meta) | Icons | `OAuth` | Yes | Unknown |
-| [Noun Project](http://api.thenounproject.com/index.html) | Icons | `OAuth` | No | Unknown |
-| [Rijksmuseum](https://www.rijksmuseum.nl/en/api) | Art | `apiKey` | Yes | Unknown |
+
+| API                                                                  | Description               | Auth     | HTTPS | CORS    |
+| -------------------------------------------------------------------- | ------------------------- | -------- | ----- | ------- |
+| [Behance](https://www.behance.net/dev)                               | Design                    | `apiKey` | Yes   | Unknown |
+| [Cooper Hewitt](https://collection.cooperhewitt.org/api)             | Smithsonian Design Museum | `apiKey` | Yes   | Unknown |
+| [Dribbble](http://developer.dribbble.com/v2/)                        | Design                    | `OAuth`  | No    | Unknown |
+| [Harvard Art Museums](https://github.com/harvardartmuseums/api-docs) | Art                       | `apiKey` | No    | Unknown |
+| [Iconfinder](https://developer.iconfinder.com)                       | Icons                     | `apiKey` | Yes   | Unknown |
+| [Icons8](http://docs.icons8.apiary.io/#reference/0/meta)             | Icons                     | `OAuth`  | Yes   | Unknown |
+| [Noun Project](http://api.thenounproject.com/index.html)             | Icons                     | `OAuth`  | No    | Unknown |
+| [Rijksmuseum](https://www.rijksmuseum.nl/en/api)                     | Art                       | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Books
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Bhagavad Gita](https://bhagavadgita.io/api) | Bhagavad Gita text | `OAuth` | Yes | Yes |
-| [BookNomads](https://www.booknomads.com/dev) | Books published in the Netherlands and Flanders (about 2.5 million), book covers and related data | No | Yes | Unknown |
-| [British National Bibliography](http://bnb.data.bl.uk/) | Books | No | No | Unknown |
-| [Goodreads](https://www.goodreads.com/api) | Books | `apiKey` | Yes | Unknown |
-| [Google Books](https://developers.google.com/books/) | Books | `OAuth` | Yes | Unknown |
-| [LibGen](http://garbage.world/posts/libgen/) | Library Genesis search engine | No | No | Unknown |
-| [Open Library](https://openlibrary.org/developers/api) | Books, book covers and related data | No | Yes | Unknown |
-| [Penguin Publishing](http://www.penguinrandomhouse.biz/webservices/rest/) | Books, book covers and related data | No | Yes | Unknown |
+
+| API                                                                       | Description                                                                                       | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Bhagavad Gita](https://bhagavadgita.io/api)                              | Bhagavad Gita text                                                                                | `OAuth`  | Yes   | Yes     |
+| [BookNomads](https://www.booknomads.com/dev)                              | Books published in the Netherlands and Flanders (about 2.5 million), book covers and related data | No       | Yes   | Unknown |
+| [British National Bibliography](http://bnb.data.bl.uk/)                   | Books                                                                                             | No       | No    | Unknown |
+| [Goodreads](https://www.goodreads.com/api)                                | Books                                                                                             | `apiKey` | Yes   | Unknown |
+| [Google Books](https://developers.google.com/books/)                      | Books                                                                                             | `OAuth`  | Yes   | Unknown |
+| [LibGen](http://garbage.world/posts/libgen/)                              | Library Genesis search engine                                                                     | No       | No    | Unknown |
+| [Open Library](https://openlibrary.org/developers/api)                    | Books, book covers and related data                                                               | No       | Yes   | Unknown |
+| [Penguin Publishing](http://www.penguinrandomhouse.biz/webservices/rest/) | Books, book covers and related data                                                               | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Business
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Charity Search](http://charityapi.orghunter.com/) | Non-profit charity data | `apiKey` | No | Unknown |
-| [Clearbit Logo](https://clearbit.com/docs#logo-api) | Search for company logos and embed them in your projects | `apiKey` | Yes | Unknown |
-| [Domainsdb.info](https://domainsdb.info/) | Registered Domain Names Search | No | Yes | Unknown |
-| [Freelancer](https://developers.freelancer.com) | Hire freelancers to get work done | `OAuth` | Yes | Unknown |
-| [Gmail](https://developers.google.com/gmail/api/) | Flexible, RESTful access to the user's inbox | `OAuth` | Yes | Unknown |
-| [Google Analytics](https://developers.google.com/analytics/) | Collect, configure and analyze your data to reach the right audience | `OAuth` | Yes | Unknown |
-| [MailboxValidator](https://www.mailboxvalidator.com/api-single-validation) | Validate email address to improve deliverability | `apiKey` | Yes | Unknown |
-| [mailgun](https://www.mailgun.com/) | Email Service | `apiKey` | Yes | Unknown |
-| [markerapi](http://www.markerapi.com/) | Trademark Search | No | No | Unknown |
-| [Repetiti](https://developers.repetiti.com/) | Repetiti 3d Printer Management Service, access and control 3d printers easily | `apiKey` | Yes | Yes |
-| [Ticksel](https://ticksel.com) | Friendly website analytics made for humans | No | Yes | Unknown |
-| [Trello](https://developers.trello.com/) | Boards, lists and cards to help you organize and prioritize your projects | `OAuth` | Yes | Unknown |
+
+| API                                                                        | Description                                                                   | Auth     | HTTPS | CORS    |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Charity Search](http://charityapi.orghunter.com/)                         | Non-profit charity data                                                       | `apiKey` | No    | Unknown |
+| [Clearbit Logo](https://clearbit.com/docs#logo-api)                        | Search for company logos and embed them in your projects                      | `apiKey` | Yes   | Unknown |
+| [Domainsdb.info](https://domainsdb.info/)                                  | Registered Domain Names Search                                                | No       | Yes   | Unknown |
+| [Freelancer](https://developers.freelancer.com)                            | Hire freelancers to get work done                                             | `OAuth`  | Yes   | Unknown |
+| [Gmail](https://developers.google.com/gmail/api/)                          | Flexible, RESTful access to the user's inbox                                  | `OAuth`  | Yes   | Unknown |
+| [Google Analytics](https://developers.google.com/analytics/)               | Collect, configure and analyze your data to reach the right audience          | `OAuth`  | Yes   | Unknown |
+| [MailboxValidator](https://www.mailboxvalidator.com/api-single-validation) | Validate email address to improve deliverability                              | `apiKey` | Yes   | Unknown |
+| [mailgun](https://www.mailgun.com/)                                        | Email Service                                                                 | `apiKey` | Yes   | Unknown |
+| [markerapi](http://www.markerapi.com/)                                     | Trademark Search                                                              | No       | No    | Unknown |
+| [Repetiti](https://developers.repetiti.com/)                               | Repetiti 3d Printer Management Service, access and control 3d printers easily | `apiKey` | Yes   | Yes     |
+| [Ticksel](https://ticksel.com)                                             | Friendly website analytics made for humans                                    | No       | Yes   | Unknown |
+| [Trello](https://developers.trello.com/)                                   | Boards, lists and cards to help you organize and prioritize your projects     | `OAuth`  | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Calendar
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Calendar Index](https://www.calendarindex.com/) | Worldwide Holidays and Working Days | `apiKey` | Yes | Yes |
-| [Church Calendar](http://calapi.inadiutorium.cz/) | Catholic liturgical calendar | No | No | Unknown |
-| [Czech Namedays Calendar](http://svatky.adresa.info/) | Lookup for a name and returns nameday date | No | No | Unknown |
-| [Google Calendar](https://developers.google.com/google-apps/calendar/) | Display, create and modify Google calendar events | `OAuth` | Yes | Unknown |
-| [Hebrew Calendar](https://www.hebcal.com/home/developer-apis) | Convert between Gregorian and Hebrew, fetch Shabbat and Holiday times, etc | No | No | Unknown |
-| [Holidays](https://holidayapi.com/) | Historical data regarding holidays | `apiKey` | Yes | Unknown |
-| [LectServe](http://www.lectserve.com) | Protestant liturgical calendar | No | No | Unknown |
-| [Nager.Date](https://date.nager.at) | Public holidays for more than 90 countries | No | Yes | No |
-| [Namedays Calendar](https://api.abalin.net/) | Provides namedays for multiple countries | No | Yes | Yes |
-| [Non-Working Days](https://github.com/gadael/icsdb) | Database of ICS files for non working days | No | Yes | Unknown |
-| [Russian Calendar](https://github.com/egno/work-calendar) | Check if a date is a Russian holiday or not | No | Yes | No |
+
+| API                                                                    | Description                                                                | Auth     | HTTPS | CORS    |
+| ---------------------------------------------------------------------- | -------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Calendar Index](https://www.calendarindex.com/)                       | Worldwide Holidays and Working Days                                        | `apiKey` | Yes   | Yes     |
+| [Church Calendar](http://calapi.inadiutorium.cz/)                      | Catholic liturgical calendar                                               | No       | No    | Unknown |
+| [Czech Namedays Calendar](http://svatky.adresa.info/)                  | Lookup for a name and returns nameday date                                 | No       | No    | Unknown |
+| [Google Calendar](https://developers.google.com/google-apps/calendar/) | Display, create and modify Google calendar events                          | `OAuth`  | Yes   | Unknown |
+| [Hebrew Calendar](https://www.hebcal.com/home/developer-apis)          | Convert between Gregorian and Hebrew, fetch Shabbat and Holiday times, etc | No       | No    | Unknown |
+| [Holidays](https://holidayapi.com/)                                    | Historical data regarding holidays                                         | `apiKey` | Yes   | Unknown |
+| [LectServe](http://www.lectserve.com)                                  | Protestant liturgical calendar                                             | No       | No    | Unknown |
+| [Nager.Date](https://date.nager.at)                                    | Public holidays for more than 90 countries                                 | No       | Yes   | No      |
+| [Namedays Calendar](https://api.abalin.net/)                           | Provides namedays for multiple countries                                   | No       | Yes   | Yes     |
+| [Non-Working Days](https://github.com/gadael/icsdb)                    | Database of ICS files for non working days                                 | No       | Yes   | Unknown |
+| [Russian Calendar](https://github.com/egno/work-calendar)              | Check if a date is a Russian holiday or not                                | No       | Yes   | No      |
 
 **[⬆ Back to Index](#index)**
+
 ### Cloud Storage & File Sharing
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Box](https://developer.box.com/) | File Sharing and Storage | `OAuth` | Yes | Unknown |
-| [Dropbox](https://www.dropbox.com/developers) | File Sharing and Storage | `OAuth` | Yes | Unknown |
-| [Google Drive](https://developers.google.com/drive/) | File Sharing and Storage | `OAuth` | Yes | Unknown |
-| [OneDrive](https://dev.onedrive.com/) | File Sharing and Storage | `OAuth` | Yes | Unknown |
-| [Pastebin](https://pastebin.com/api/) | Plain Text Storage | `apiKey` | Yes | Unknown |
-| [Temporal](https://gateway.temporal.cloud/ipns/docs.api.temporal.cloud) | IPFS based file storage and sharing with optional IPNS naming | `apiKey` | Yes | No |
-| [WeTransfer](https://developers.wetransfer.com) | File Sharing | `apiKey` | Yes | Yes |
+
+| API                                                                     | Description                                                   | Auth     | HTTPS | CORS    |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------- | -------- | ----- | ------- |
+| [Box](https://developer.box.com/)                                       | File Sharing and Storage                                      | `OAuth`  | Yes   | Unknown |
+| [Dropbox](https://www.dropbox.com/developers)                           | File Sharing and Storage                                      | `OAuth`  | Yes   | Unknown |
+| [Google Drive](https://developers.google.com/drive/)                    | File Sharing and Storage                                      | `OAuth`  | Yes   | Unknown |
+| [OneDrive](https://dev.onedrive.com/)                                   | File Sharing and Storage                                      | `OAuth`  | Yes   | Unknown |
+| [Pastebin](https://pastebin.com/api/)                                   | Plain Text Storage                                            | `apiKey` | Yes   | Unknown |
+| [Temporal](https://gateway.temporal.cloud/ipns/docs.api.temporal.cloud) | IPFS based file storage and sharing with optional IPNS naming | `apiKey` | Yes   | No      |
+| [WeTransfer](https://developers.wetransfer.com)                         | File Sharing                                                  | `apiKey` | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
+
 ### Continuous Integration
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [CircleCI](https://circleci.com/docs/api/v1-reference/) | Automate the software development process using continuous integration and continuous delivery | `apiKey` | Yes | Unknown |
-| [Codeship](https://apidocs.codeship.com/) | Codeship is a Continuous Integration Platform in the cloud | `apiKey` | Yes | Unknown |
-| [Travis CI](https://docs.travis-ci.com/api/) | Sync your GitHub projects with Travis CI to test your code in minutes | `apiKey` | Yes | Unknown |
+
+| API                                                     | Description                                                                                    | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [CircleCI](https://circleci.com/docs/api/v1-reference/) | Automate the software development process using continuous integration and continuous delivery | `apiKey` | Yes   | Unknown |
+| [Codeship](https://apidocs.codeship.com/)               | Codeship is a Continuous Integration Platform in the cloud                                     | `apiKey` | Yes   | Unknown |
+| [Travis CI](https://docs.travis-ci.com/api/)            | Sync your GitHub projects with Travis CI to test your code in minutes                          | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Cryptocurrency
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Binance](https://github.com/binance-exchange/binance-official-api-docs) | Exchange for Trading Cryptocurrencies based in China | `apiKey` | Yes | Unknown |
-| [BitcoinAverage](https://apiv2.bitcoinaverage.com/) | Digital Asset Price Data for the blockchain industry | `apiKey` | Yes | Unknown |
-| [BitcoinCharts](https://bitcoincharts.com/about/exchanges/) | Financial and Technical Data related to the Bitcoin Network | No | Yes | Unknown |
-| [Bitfinex](https://docs.bitfinex.com/docs/getting-started) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |
-| [Bitmex](https://www.bitmex.com/app/apiOverview) | Real-Time Cryptocurrency derivatives trading platform based in Hong Kong | `apiKey` | Yes | Unknown |
-| [Bittrex](https://bittrex.com/Home/Api) | Next Generation Crypto Trading Platform | `apiKey` | Yes | Unknown |
-| [Block](https://www.block.io/docs/basic) | Bitcoin Payment, Wallet & Transaction Data | `apiKey` | Yes | Unknown |
-| [Blockchain](https://www.blockchain.info/api) | Bitcoin Payment, Wallet & Transaction Data | No | Yes | Unknown |
-| [CoinAPI](https://docs.coinapi.io/) | All Currency Exchanges integrate under a single api | `apiKey` | Yes | No |
-| [Coinbase](https://developers.coinbase.com) | Bitcoin, Bitcoin Cash, Litecoin and Ethereum Prices | `apiKey` | Yes | Unknown |
-| [Coinbase Pro](https://docs.pro.coinbase.com/#api) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |
-| [CoinDesk](http://www.coindesk.com/api/) | Bitcoin Price Index | No | No | Unknown |
-| [CoinGecko](http://www.coingecko.com/api) | Cryptocurrency Price, Market, and Developer/Social Data | No | Yes | Yes |
-| [Coinigy](https://coinigy.docs.apiary.io) | Interacting with Coinigy Accounts and Exchange Directly | `apiKey` | Yes | Unknown |
-| [CoinLayer](https://coinlayer.com) | Real-time Crypto Currency Exchange Rates | `apiKey` | Yes | Unknown |
-| [Coinlib](https://coinlib.io/apidocs) | Crypto Currency Prices | `apiKey` | Yes | Unknown |
-| [Coinlore](https://www.coinlore.com/cryptocurrency-data-api) | Cryptocurrencies prices, volume and more | No | Yes | Unknown |
-| [CoinMarketCap](https://coinmarketcap.com/api/) | Cryptocurrencies Prices | `apiKey` | Yes | Unknown |
-| [Coinpaprika](https://api.coinpaprika.com) | Cryptocurrencies prices, volume and more | No | Yes | Yes |
-| [CoinRanking](https://docs.coinranking.com/) | Live Cryptocurrency data | No | Yes | Unknown |
-| [CryptoCompare](https://www.cryptocompare.com/api#) | Cryptocurrencies Comparison | No | Yes | Unknown |
-| [Cryptonator](https://www.cryptonator.com/api/) | Cryptocurrencies Exchange Rates | No | Yes | Unknown |
-| [Gemini](https://docs.gemini.com/rest-api/) | Cryptocurrencies Exchange | No | Yes | Unknown |
-| [ICObench](https://icobench.com/developers) | Various information on listing, ratings, stats, and more | `apiKey` | Yes | Unknown |
-| [Livecoin](https://www.livecoin.net/api) | Cryptocurrency Exchange | No | Yes | Unknown |
-| [MercadoBitcoin](https://www.mercadobitcoin.net/api-doc/) | Brazilian Cryptocurrency Information | No | Yes | Unknown |
-| [Nexchange](https://nexchange2.docs.apiary.io/) | Automated cryptocurrency exchange service | No | No | Yes |
-| [NiceHash](https://docs.nicehash.com/) | Largest Crypto Mining Marketplace | `apiKey` | Yes | Unknown |
-| [Poloniex](https://poloniex.com/support/api/) | US based digital asset exchange | `apiKey` | Yes | Unknown |
-| [WorldCoinIndex](https://www.worldcoinindex.com/apiservice) | Cryptocurrencies Prices | `apiKey` | Yes | Unknown |
+
+| API                                                                      | Description                                                              | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------ | -------- | ----- | ------- |
+| [Binance](https://github.com/binance-exchange/binance-official-api-docs) | Exchange for Trading Cryptocurrencies based in China                     | `apiKey` | Yes   | Unknown |
+| [BitcoinAverage](https://apiv2.bitcoinaverage.com/)                      | Digital Asset Price Data for the blockchain industry                     | `apiKey` | Yes   | Unknown |
+| [BitcoinCharts](https://bitcoincharts.com/about/exchanges/)              | Financial and Technical Data related to the Bitcoin Network              | No       | Yes   | Unknown |
+| [Bitfinex](https://docs.bitfinex.com/docs/getting-started)               | Cryptocurrency Trading Platform                                          | `apiKey` | Yes   | Unknown |
+| [Bitmex](https://www.bitmex.com/app/apiOverview)                         | Real-Time Cryptocurrency derivatives trading platform based in Hong Kong | `apiKey` | Yes   | Unknown |
+| [Bittrex](https://bittrex.com/Home/Api)                                  | Next Generation Crypto Trading Platform                                  | `apiKey` | Yes   | Unknown |
+| [Block](https://www.block.io/docs/basic)                                 | Bitcoin Payment, Wallet & Transaction Data                               | `apiKey` | Yes   | Unknown |
+| [Blockchain](https://www.blockchain.info/api)                            | Bitcoin Payment, Wallet & Transaction Data                               | No       | Yes   | Unknown |
+| [CoinAPI](https://docs.coinapi.io/)                                      | All Currency Exchanges integrate under a single api                      | `apiKey` | Yes   | No      |
+| [Coinbase](https://developers.coinbase.com)                              | Bitcoin, Bitcoin Cash, Litecoin and Ethereum Prices                      | `apiKey` | Yes   | Unknown |
+| [Coinbase Pro](https://docs.pro.coinbase.com/#api)                       | Cryptocurrency Trading Platform                                          | `apiKey` | Yes   | Unknown |
+| [CoinDesk](http://www.coindesk.com/api/)                                 | Bitcoin Price Index                                                      | No       | No    | Unknown |
+| [CoinGecko](http://www.coingecko.com/api)                                | Cryptocurrency Price, Market, and Developer/Social Data                  | No       | Yes   | Yes     |
+| [Coinigy](https://coinigy.docs.apiary.io)                                | Interacting with Coinigy Accounts and Exchange Directly                  | `apiKey` | Yes   | Unknown |
+| [CoinLayer](https://coinlayer.com)                                       | Real-time Crypto Currency Exchange Rates                                 | `apiKey` | Yes   | Unknown |
+| [Coinlib](https://coinlib.io/apidocs)                                    | Crypto Currency Prices                                                   | `apiKey` | Yes   | Unknown |
+| [Coinlore](https://www.coinlore.com/cryptocurrency-data-api)             | Cryptocurrencies prices, volume and more                                 | No       | Yes   | Unknown |
+| [CoinMarketCap](https://coinmarketcap.com/api/)                          | Cryptocurrencies Prices                                                  | `apiKey` | Yes   | Unknown |
+| [Coinpaprika](https://api.coinpaprika.com)                               | Cryptocurrencies prices, volume and more                                 | No       | Yes   | Yes     |
+| [CoinRanking](https://docs.coinranking.com/)                             | Live Cryptocurrency data                                                 | No       | Yes   | Unknown |
+| [CryptoCompare](https://www.cryptocompare.com/api#)                      | Cryptocurrencies Comparison                                              | No       | Yes   | Unknown |
+| [Cryptonator](https://www.cryptonator.com/api/)                          | Cryptocurrencies Exchange Rates                                          | No       | Yes   | Unknown |
+| [Gemini](https://docs.gemini.com/rest-api/)                              | Cryptocurrencies Exchange                                                | No       | Yes   | Unknown |
+| [ICObench](https://icobench.com/developers)                              | Various information on listing, ratings, stats, and more                 | `apiKey` | Yes   | Unknown |
+| [Livecoin](https://www.livecoin.net/api)                                 | Cryptocurrency Exchange                                                  | No       | Yes   | Unknown |
+| [MercadoBitcoin](https://www.mercadobitcoin.net/api-doc/)                | Brazilian Cryptocurrency Information                                     | No       | Yes   | Unknown |
+| [Nexchange](https://nexchange2.docs.apiary.io/)                          | Automated cryptocurrency exchange service                                | No       | No    | Yes     |
+| [NiceHash](https://docs.nicehash.com/)                                   | Largest Crypto Mining Marketplace                                        | `apiKey` | Yes   | Unknown |
+| [Poloniex](https://poloniex.com/support/api/)                            | US based digital asset exchange                                          | `apiKey` | Yes   | Unknown |
+| [WorldCoinIndex](https://www.worldcoinindex.com/apiservice)              | Cryptocurrencies Prices                                                  | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Currency Exchange
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [1Forge](https://1forge.com/forex-data-api/api-documentation) | Forex currency market data | `apiKey` | Yes | Unknown |
-| [Currencylayer](https://currencylayer.com/documentation) | Exchange rates and currency conversion | `apiKey` | Yes | Unknown |
-| [Czech National Bank](https://www.cnb.cz/cs/financni_trhy/devizovy_trh/kurzy_devizoveho_trhu/denni_kurz.xml) | A collection of exchange rates | No | Yes | Unknown |
-| [ExchangeRate-API](https://www.exchangerate-api.com) | Free currency conversion | No | Yes | Yes |
-| [Exchangeratesapi.io](https://exchangeratesapi.io) | Exchange rates with currency conversion | No | Yes | Yes |
-| [Fixer.io](http://fixer.io) | Exchange rates and currency conversion | `apiKey` | Yes | Unknown |
-| [Frankfurter](https://www.frankfurter.app/docs) | Exchange rates, currency conversion and time series | No | Yes | Yes |
-| [ratesapi](https://ratesapi.io) | Free exchange rates and historical rates | No | Yes | Unknown |
+
+| API                                                                                                          | Description                                         | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------- | -------- | ----- | ------- |
+| [1Forge](https://1forge.com/forex-data-api/api-documentation)                                                | Forex currency market data                          | `apiKey` | Yes   | Unknown |
+| [Currencylayer](https://currencylayer.com/documentation)                                                     | Exchange rates and currency conversion              | `apiKey` | Yes   | Unknown |
+| [Czech National Bank](https://www.cnb.cz/cs/financni_trhy/devizovy_trh/kurzy_devizoveho_trhu/denni_kurz.xml) | A collection of exchange rates                      | No       | Yes   | Unknown |
+| [ExchangeRate-API](https://www.exchangerate-api.com)                                                         | Free currency conversion                            | No       | Yes   | Yes     |
+| [Exchangeratesapi.io](https://exchangeratesapi.io)                                                           | Exchange rates with currency conversion             | No       | Yes   | Yes     |
+| [Fixer.io](http://fixer.io)                                                                                  | Exchange rates and currency conversion              | `apiKey` | Yes   | Unknown |
+| [Frankfurter](https://www.frankfurter.app/docs)                                                              | Exchange rates, currency conversion and time series | No       | Yes   | Yes     |
+| [ratesapi](https://ratesapi.io)                                                                              | Free exchange rates and historical rates            | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Data Validation
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Cloudmersive Validate](https://cloudmersive.com/validate-api) | Validate email addresses, phone numbers, VAT numbers and domain names | `apiKey` | Yes | Yes |
-| [languagelayer](https://languagelayer.com) | Language detection | No | Yes | Unknown |
-| [Lob.com](https://lob.com/) | US Address Verification | `apiKey` | Yes | Unknown |
-| [mailboxlayer](https://mailboxlayer.com) | Email address validation | No | Yes | Unknown |
-| [NumValidate](https://numvalidate.com) | Open Source phone number validation | No | Yes | Unknown |
-| [numverify](https://numverify.com) | Phone number validation | No | Yes | Unknown |
-| [PurgoMalum](http://www.purgomalum.com) | Content validator against profanity & obscenity | No | No | Unknown |
-| [US Autocomplete](https://smartystreets.com/docs/cloud/us-autocomplete-api) | Enter address data quickly with real-time address suggestions | `apiKey` | Yes | Yes |
-| [US Extract](https://smartystreets.com/products/apis/us-extract-api) | Extract postal addresses from any text including emails | `apiKey` | Yes | Yes |
-| [US Street Address](https://smartystreets.com/docs/cloud/us-street-api) | Validate and append data for any US postal address | `apiKey` | Yes | Yes |
-| [vatlayer](https://vatlayer.com) | VAT number validation | No | Yes | Unknown |
+
+| API                                                                         | Description                                                           | Auth     | HTTPS | CORS    |
+| --------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Cloudmersive Validate](https://cloudmersive.com/validate-api)              | Validate email addresses, phone numbers, VAT numbers and domain names | `apiKey` | Yes   | Yes     |
+| [languagelayer](https://languagelayer.com)                                  | Language detection                                                    | No       | Yes   | Unknown |
+| [Lob.com](https://lob.com/)                                                 | US Address Verification                                               | `apiKey` | Yes   | Unknown |
+| [mailboxlayer](https://mailboxlayer.com)                                    | Email address validation                                              | No       | Yes   | Unknown |
+| [NumValidate](https://numvalidate.com)                                      | Open Source phone number validation                                   | No       | Yes   | Unknown |
+| [numverify](https://numverify.com)                                          | Phone number validation                                               | No       | Yes   | Unknown |
+| [PurgoMalum](http://www.purgomalum.com)                                     | Content validator against profanity & obscenity                       | No       | No    | Unknown |
+| [US Autocomplete](https://smartystreets.com/docs/cloud/us-autocomplete-api) | Enter address data quickly with real-time address suggestions         | `apiKey` | Yes   | Yes     |
+| [US Extract](https://smartystreets.com/products/apis/us-extract-api)        | Extract postal addresses from any text including emails               | `apiKey` | Yes   | Yes     |
+| [US Street Address](https://smartystreets.com/docs/cloud/us-street-api)     | Validate and append data for any US postal address                    | `apiKey` | Yes   | Yes     |
+| [vatlayer](https://vatlayer.com)                                            | VAT number validation                                                 | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Development
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [24 Pull Requests](https://24pullrequests.com/api) | Project to promote open source collaboration during December | No | Yes | Yes |
-| [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
-| [ApiFlash](https://apiflash.com/) | Chrome based screenshot API for developers | `apiKey` | Yes | Unknown |
-| [Apility.io](https://apility.io/apidocs/) | IP, Domains and Emails anti-abuse API blocklist | No | Yes | Yes |
-| [APIs.guru](https://apis.guru/api-doc/) | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs | No | Yes | Unknown |
-| [BetterMeta](http://bettermeta.io) | Return a site's meta tags in JSON format | `X-Mashape-Key` | Yes | Unknown |
-| [Bitbucket](https://api.bitbucket.org/2.0/users/karllhughes) | Pull public information for a Bitbucket account | No | Yes | Unknown |
-| [Bored](https://www.boredapi.com/) | Find random activities to fight boredom | No | Yes | Unknown |
-| [Browshot](https://browshot.com/api/documentation) | Easily make screenshots of web pages in any screen size, as any device | `apiKey` | Yes | Unknown |
-| [CDNJS](https://api.cdnjs.com/libraries/jquery) | Library info on CDNJS | No | Yes | Unknown |
-| [Changelogs.md](https://changelogs.md) | Structured changelog metadata from open source projects | No | Yes | Unknown |
-| [CountAPI](https://countapi.xyz) | Free and simple counting service. You can use it to track page hits and specific events | No | Yes | Yes |
-| [DigitalOcean Status](https://status.digitalocean.com/api/v1) | Status of all DigitalOcean services | No | Yes | Unknown |
-| [DomainDb Info](https://domainsdb.info/apidomainsdb/index.php) | Domain name search to find all domains containing particular words/phrases/etc | No | Yes | Unknown |
-| [Faceplusplus](https://www.faceplusplus.com/) | A tool to detect face | `OAuth` | Yes | Unknown |
-| [Genderize.io](https://genderize.io) | Estimates a gender from a first name | No | Yes | Yes |
-| [GitHub](https://developer.github.com/v3/) | Make use of GitHub repositories, code and user info programmatically | `OAuth` | Yes | Yes |
-| [Gitlab](https://docs.gitlab.com/ee/api/) | Automate GitLab interaction programmatically | `OAuth` | Yes | Unknown |
-| [Gitter](https://github.com/gitterHQ/docs) | Chat for GitHub | `OAuth` | Yes | Unknown |
-| [HTTP2.Pro](https://http2.pro/doc/api) | Test endpoints for client and server HTTP/2 protocol support | No | Yes | Unknown |
-| [IBM Text to Speech](https://console.bluemix.net/docs/services/text-to-speech/getting-started.html) | Convert text to speech | `apiKey` | Yes | Yes |
-| [import.io](http://api.docs.import.io/) | Retrieve structured data from a website or RSS feed | `apiKey` | Yes | Unknown |
-| [IPify](https://www.ipify.org/) | A simple IP Address API | No | Yes | Unknown |
-| [IPinfo](https://ipinfo.io/developers) | Another simple IP Address API | No | Yes | Unknown |
-| [JSON 2 JSONP](https://json2jsonp.com/) | Convert JSON to JSONP (on-the-fly) for easy cross-domain data requests using client-side JavaScript | No | Yes | Unknown |
-| [JSONbin.io](https://jsonbin.io) | Free JSON storage service. Ideal for small scale Web apps, Websites and Mobile apps | `apiKey` | Yes | Yes |
-| [Judge0](https://api.judge0.com/) | Compile and run source code | No | Yes | Unknown |
-| [Let's Validate](https://github.com/letsvalidate/api) | Uncovers the technologies used on websites and URL to thumbnail | No | Yes | Unknown |
-| [License-API](https://github.com/cmccandless/license-api/blob/master/README.md) | Unofficial REST API for choosealicense.com | No | Yes | No |
-| [LiveEdu](https://www.liveedu.tv/developer/applications/) | Live Coding Streaming | `OAuth` | Yes | Unknown |
-| [MAC address vendor lookup](https://macaddress.io) | Retrieve vendor details and other information regarding a given MAC address or an OUI | `apiKey` | Yes | Yes |
-| [Myjson](http://myjson.com/api) | A simple JSON store for your web or mobile app | No | No | Unknown |
-| [Nationalize.io](https://nationalize.io) | Estimate the nationality of a first name | No | Yes | Yes |
-| [OOPSpam](https://oopspam.com/) | Multiple spam filtering service | No | Yes | Yes |
-| [Plino](https://plino.herokuapp.com/) | Spam filtering system | No | Yes | Unknown |
-| [Postman](https://docs.api.getpostman.com/) | Tool for testing APIs | `apiKey` | Yes | Unknown |
-| [ProxyCrawl](https://proxycrawl.com) | Scraping and crawling anticaptcha service | `apiKey` | Yes | Unknown |
-| [Public APIs](https://github.com/davemachado/public-api) | A collective list of free JSON APIs for use in web development | No | Yes | Unknown |
-| [Pusher Beams](https://pusher.com/beams) | Push notifications for Android & iOS | `apiKey` | Yes | Unknown |
-| [QR code](http://qrtag.net/api/) | Create an easy to read QR code and URL shortener | No | Yes | Yes |
-| [QR code](http://goqr.me/api/) | Generate and decode / read QR code graphics | No | Yes | Unknown |
-| [QuickChart](https://quickchart.io/) | Generate chart and graph images | No | Yes | Yes |
-| [ReqRes](https://reqres.in/ ) | A hosted REST-API ready to respond to your AJAX requests | No | Yes | Unknown |
-| [Scrape Website Email](https://market.mashape.com/tommytcchan/scrape-website-email) | Grabs email addresses from a URL | `X-Mashape-Key` | Yes | Unknown |
-| [ScraperApi](https://www.scraperapi.com) | Easily build scalable web scrapers | `apiKey` | Yes | Unknown |
-| [ScreenshotAPI.net](https://screenshotapi.net/) | Create pixel-perfect website screenshots | `apiKey` | Yes | Yes |
-| [SHOUTCLOUD](http://shoutcloud.io/) | ALL-CAPS AS A SERVICE | No | No | Unknown |
-| [StackExchange](https://api.stackexchange.com/) | Q&A forum for developers | `OAuth` | Yes | Unknown |
-| [Verse](https://verse.pawelad.xyz/) | Check what's the latest version of your favorite open-source project | No | Yes | Unknown |
-| [XML to JSON](https://developers.wso2apistore.com/) | Integration developer utility APIs | No | Yes | Unknown |
+
+| API                                                                                                 | Description                                                                                         | Auth            | HTTPS | CORS    |
+| --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | --------------- | ----- | ------- |
+| [24 Pull Requests](https://24pullrequests.com/api)                                                  | Project to promote open source collaboration during December                                        | No              | Yes   | Yes     |
+| [Agify.io](https://agify.io)                                                                        | Estimates the age from a first name                                                                 | No              | Yes   | Yes     |
+| [ApiFlash](https://apiflash.com/)                                                                   | Chrome based screenshot API for developers                                                          | `apiKey`        | Yes   | Unknown |
+| [Apility.io](https://apility.io/apidocs/)                                                           | IP, Domains and Emails anti-abuse API blocklist                                                     | No              | Yes   | Yes     |
+| [APIs.guru](https://apis.guru/api-doc/)                                                             | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs                                       | No              | Yes   | Unknown |
+| [BetterMeta](http://bettermeta.io)                                                                  | Return a site's meta tags in JSON format                                                            | `X-Mashape-Key` | Yes   | Unknown |
+| [Bitbucket](https://api.bitbucket.org/2.0/users/karllhughes)                                        | Pull public information for a Bitbucket account                                                     | No              | Yes   | Unknown |
+| [Bored](https://www.boredapi.com/)                                                                  | Find random activities to fight boredom                                                             | No              | Yes   | Unknown |
+| [Browshot](https://browshot.com/api/documentation)                                                  | Easily make screenshots of web pages in any screen size, as any device                              | `apiKey`        | Yes   | Unknown |
+| [CDNJS](https://api.cdnjs.com/libraries/jquery)                                                     | Library info on CDNJS                                                                               | No              | Yes   | Unknown |
+| [Changelogs.md](https://changelogs.md)                                                              | Structured changelog metadata from open source projects                                             | No              | Yes   | Unknown |
+| [CountAPI](https://countapi.xyz)                                                                    | Free and simple counting service. You can use it to track page hits and specific events             | No              | Yes   | Yes     |
+| [DigitalOcean Status](https://status.digitalocean.com/api/v1)                                       | Status of all DigitalOcean services                                                                 | No              | Yes   | Unknown |
+| [DomainDb Info](https://domainsdb.info/apidomainsdb/index.php)                                      | Domain name search to find all domains containing particular words/phrases/etc                      | No              | Yes   | Unknown |
+| [Faceplusplus](https://www.faceplusplus.com/)                                                       | A tool to detect face                                                                               | `OAuth`         | Yes   | Unknown |
+| [Genderize.io](https://genderize.io)                                                                | Estimates a gender from a first name                                                                | No              | Yes   | Yes     |
+| [GitHub](https://developer.github.com/v3/)                                                          | Make use of GitHub repositories, code and user info programmatically                                | `OAuth`         | Yes   | Yes     |
+| [Gitlab](https://docs.gitlab.com/ee/api/)                                                           | Automate GitLab interaction programmatically                                                        | `OAuth`         | Yes   | Unknown |
+| [Gitter](https://github.com/gitterHQ/docs)                                                          | Chat for GitHub                                                                                     | `OAuth`         | Yes   | Unknown |
+| [HTTP2.Pro](https://http2.pro/doc/api)                                                              | Test endpoints for client and server HTTP/2 protocol support                                        | No              | Yes   | Unknown |
+| [IBM Text to Speech](https://console.bluemix.net/docs/services/text-to-speech/getting-started.html) | Convert text to speech                                                                              | `apiKey`        | Yes   | Yes     |
+| [import.io](http://api.docs.import.io/)                                                             | Retrieve structured data from a website or RSS feed                                                 | `apiKey`        | Yes   | Unknown |
+| [IPify](https://www.ipify.org/)                                                                     | A simple IP Address API                                                                             | No              | Yes   | Unknown |
+| [IPinfo](https://ipinfo.io/developers)                                                              | Another simple IP Address API                                                                       | No              | Yes   | Unknown |
+| [JSON 2 JSONP](https://json2jsonp.com/)                                                             | Convert JSON to JSONP (on-the-fly) for easy cross-domain data requests using client-side JavaScript | No              | Yes   | Unknown |
+| [JSONbin.io](https://jsonbin.io)                                                                    | Free JSON storage service. Ideal for small scale Web apps, Websites and Mobile apps                 | `apiKey`        | Yes   | Yes     |
+| [Judge0](https://api.judge0.com/)                                                                   | Compile and run source code                                                                         | No              | Yes   | Unknown |
+| [Let's Validate](https://github.com/letsvalidate/api)                                               | Uncovers the technologies used on websites and URL to thumbnail                                     | No              | Yes   | Unknown |
+| [License-API](https://github.com/cmccandless/license-api/blob/master/README.md)                     | Unofficial REST API for choosealicense.com                                                          | No              | Yes   | No      |
+| [LiveEdu](https://www.liveedu.tv/developer/applications/)                                           | Live Coding Streaming                                                                               | `OAuth`         | Yes   | Unknown |
+| [MAC address vendor lookup](https://macaddress.io)                                                  | Retrieve vendor details and other information regarding a given MAC address or an OUI               | `apiKey`        | Yes   | Yes     |
+| [Myjson](http://myjson.com/api)                                                                     | A simple JSON store for your web or mobile app                                                      | No              | No    | Unknown |
+| [Nationalize.io](https://nationalize.io)                                                            | Estimate the nationality of a first name                                                            | No              | Yes   | Yes     |
+| [OOPSpam](https://oopspam.com/)                                                                     | Multiple spam filtering service                                                                     | No              | Yes   | Yes     |
+| [Plino](https://plino.herokuapp.com/)                                                               | Spam filtering system                                                                               | No              | Yes   | Unknown |
+| [Postman](https://docs.api.getpostman.com/)                                                         | Tool for testing APIs                                                                               | `apiKey`        | Yes   | Unknown |
+| [ProxyCrawl](https://proxycrawl.com)                                                                | Scraping and crawling anticaptcha service                                                           | `apiKey`        | Yes   | Unknown |
+| [Public APIs](https://github.com/davemachado/public-api)                                            | A collective list of free JSON APIs for use in web development                                      | No              | Yes   | Unknown |
+| [Pusher Beams](https://pusher.com/beams)                                                            | Push notifications for Android & iOS                                                                | `apiKey`        | Yes   | Unknown |
+| [QR code](http://qrtag.net/api/)                                                                    | Create an easy to read QR code and URL shortener                                                    | No              | Yes   | Yes     |
+| [QR code](http://goqr.me/api/)                                                                      | Generate and decode / read QR code graphics                                                         | No              | Yes   | Unknown |
+| [QuickChart](https://quickchart.io/)                                                                | Generate chart and graph images                                                                     | No              | Yes   | Yes     |
+| [ReqRes](https://reqres.in/)                                                                        | A hosted REST-API ready to respond to your AJAX requests                                            | No              | Yes   | Unknown |
+| [Scrape Website Email](https://market.mashape.com/tommytcchan/scrape-website-email)                 | Grabs email addresses from a URL                                                                    | `X-Mashape-Key` | Yes   | Unknown |
+| [ScraperApi](https://www.scraperapi.com)                                                            | Easily build scalable web scrapers                                                                  | `apiKey`        | Yes   | Unknown |
+| [ScreenshotAPI.net](https://screenshotapi.net/)                                                     | Create pixel-perfect website screenshots                                                            | `apiKey`        | Yes   | Yes     |
+| [SHOUTCLOUD](http://shoutcloud.io/)                                                                 | ALL-CAPS AS A SERVICE                                                                               | No              | No    | Unknown |
+| [StackExchange](https://api.stackexchange.com/)                                                     | Q&A forum for developers                                                                            | `OAuth`         | Yes   | Unknown |
+| [Verse](https://verse.pawelad.xyz/)                                                                 | Check what's the latest version of your favorite open-source project                                | No              | Yes   | Unknown |
+| [XML to JSON](https://developers.wso2apistore.com/)                                                 | Integration developer utility APIs                                                                  | No              | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Dictionaries
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Lingua Robot](https://www.linguarobot.io) | Word definitions, pronunciations, synonyms, antonyms and others | `apiKey` | Yes | Yes |
-| [Merriam-Webster](https://dictionaryapi.com/) | Dictionary and Thesaurus Data | `apiKey` | Yes | Unknown |
-| [OwlBot](https://owlbot.info/) | Definitions with example sentence and photo if available | `apiKey` | Yes | Yes |
-| [Oxford](https://developer.oxforddictionaries.com/) | Dictionary Data | `apiKey` | Yes | No |
-| [Wordnik](http://developer.wordnik.com) | Dictionary Data | `apiKey` | No | Unknown |
-| [Words](https://www.wordsapi.com/) | Definitions and synonyms for more than 150,000 words | `apiKey` | Yes | Unknown |
+
+| API                                                 | Description                                                     | Auth     | HTTPS | CORS    |
+| --------------------------------------------------- | --------------------------------------------------------------- | -------- | ----- | ------- |
+| [Lingua Robot](https://www.linguarobot.io)          | Word definitions, pronunciations, synonyms, antonyms and others | `apiKey` | Yes   | Yes     |
+| [Merriam-Webster](https://dictionaryapi.com/)       | Dictionary and Thesaurus Data                                   | `apiKey` | Yes   | Unknown |
+| [OwlBot](https://owlbot.info/)                      | Definitions with example sentence and photo if available        | `apiKey` | Yes   | Yes     |
+| [Oxford](https://developer.oxforddictionaries.com/) | Dictionary Data                                                 | `apiKey` | Yes   | No      |
+| [Wordnik](http://developer.wordnik.com)             | Dictionary Data                                                 | `apiKey` | No    | Unknown |
+| [Words](https://www.wordsapi.com/)                  | Definitions and synonyms for more than 150,000 words            | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Documents & Productivity
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Cloudmersive Document and Data Conversion](https://cloudmersive.com/convert-api) | HTML/URL to PDF/PNG, Office documents to PDF, image conversion | `apiKey` | Yes | Yes |
-| [File.io](https://www.file.io) | File Sharing | No | Yes | Unknown |
-| [Mercury](https://mercury.postlight.com/web-parser/) | Web parser | `apiKey` | Yes | Unknown |
-| [pdflayer](https://pdflayer.com) | HTML/URL to PDF | `apiKey` | Yes | Unknown |
-| [Pocket](https://getpocket.com/developer/) | Bookmarking service | `OAuth` | Yes | Unknown |
-| [PrexView](https://prexview.com) | Data from XML or JSON to PDF, HTML or Image | `apiKey` | Yes | Unknown |
-| [Restpack](https://restpack.io/) | Provides screenshot, HTML to PDF and content extraction APIs | `apiKey` | Yes | Unknown |
-| [Todoist](https://developer.todoist.com) | Todo Lists | `OAuth` | Yes | Unknown |
-| [Vector Express](http://vector.express) | Free vector file converting API | No | No | Yes |
-| [WakaTime](https://wakatime.com/developers) | Automated time tracking leaderboards for programmers | No | Yes | Unknown |
-| [Wunderlist](https://developer.wunderlist.com/documentation) | Todo Lists | `OAuth` | Yes | Unknown |
+
+| API                                                                               | Description                                                    | Auth     | HTTPS | CORS    |
+| --------------------------------------------------------------------------------- | -------------------------------------------------------------- | -------- | ----- | ------- |
+| [Cloudmersive Document and Data Conversion](https://cloudmersive.com/convert-api) | HTML/URL to PDF/PNG, Office documents to PDF, image conversion | `apiKey` | Yes   | Yes     |
+| [File.io](https://www.file.io)                                                    | File Sharing                                                   | No       | Yes   | Unknown |
+| [Mercury](https://mercury.postlight.com/web-parser/)                              | Web parser                                                     | `apiKey` | Yes   | Unknown |
+| [pdflayer](https://pdflayer.com)                                                  | HTML/URL to PDF                                                | `apiKey` | Yes   | Unknown |
+| [Pocket](https://getpocket.com/developer/)                                        | Bookmarking service                                            | `OAuth`  | Yes   | Unknown |
+| [PrexView](https://prexview.com)                                                  | Data from XML or JSON to PDF, HTML or Image                    | `apiKey` | Yes   | Unknown |
+| [Restpack](https://restpack.io/)                                                  | Provides screenshot, HTML to PDF and content extraction APIs   | `apiKey` | Yes   | Unknown |
+| [Todoist](https://developer.todoist.com)                                          | Todo Lists                                                     | `OAuth`  | Yes   | Unknown |
+| [Vector Express](http://vector.express)                                           | Free vector file converting API                                | No       | No    | Yes     |
+| [WakaTime](https://wakatime.com/developers)                                       | Automated time tracking leaderboards for programmers           | No       | Yes   | Unknown |
+| [Wunderlist](https://developer.wunderlist.com/documentation)                      | Todo Lists                                                     | `OAuth`  | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Environment
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [AirVisual](https://airvisual.com/api) | Air quality and weather data | `apiKey` | Yes | Unknown |
-| [GrünstromIndex](https://www.corrently.de/hintergrund/gruenstromindex/index.html) | Green Power Index for Germany (Grünstromindex/GSI) | No | No | Yes |
-| [OpenAQ](https://docs.openaq.org/) | Open air quality data | `apiKey` | Yes | Unknown |
-| [PM25.in](http://www.pm25.in/api_doc) | Air quality of China | `apiKey` | No | Unknown |
-| [PVWatts](https://developer.nrel.gov/docs/solar/pvwatts/v6/) | Energy production photovoltaic (PV) energy systems | `apiKey` | Yes | Unknown |
-| [UK Carbon Intensity](https://carbon-intensity.github.io/api-definitions/#carbon-intensity-api-v1-0-0) | The Official Carbon Intensity API for Great Britain developed by National Grid | No | Yes | Unknown |
+
+| API                                                                                                    | Description                                                                    | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ | -------- | ----- | ------- |
+| [AirVisual](https://airvisual.com/api)                                                                 | Air quality and weather data                                                   | `apiKey` | Yes   | Unknown |
+| [GrünstromIndex](https://www.corrently.de/hintergrund/gruenstromindex/index.html)                      | Green Power Index for Germany (Grünstromindex/GSI)                             | No       | No    | Yes     |
+| [OpenAQ](https://docs.openaq.org/)                                                                     | Open air quality data                                                          | `apiKey` | Yes   | Unknown |
+| [PM25.in](http://www.pm25.in/api_doc)                                                                  | Air quality of China                                                           | `apiKey` | No    | Unknown |
+| [PVWatts](https://developer.nrel.gov/docs/solar/pvwatts/v6/)                                           | Energy production photovoltaic (PV) energy systems                             | `apiKey` | Yes   | Unknown |
+| [UK Carbon Intensity](https://carbon-intensity.github.io/api-definitions/#carbon-intensity-api-v1-0-0) | The Official Carbon Intensity API for Great Britain developed by National Grid | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Events
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Eventbrite](https://www.eventbrite.com/developer/v3/) | Find events | `OAuth` | Yes | Unknown |
-| [Picatic](http://developer.picatic.com/?utm_medium=web&utm_source=github&utm_campaign=public-apis%20repo&utm_content=toddmotto) | Sell tickets anywhere | `apiKey` | Yes | Unknown |
-| [Ticketmaster](http://developer.ticketmaster.com/products-and-docs/apis/getting-started/) | Search events, attractions, or venues | `apiKey` | Yes | Unknown |
+
+| API                                                                                                                             | Description                           | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | -------- | ----- | ------- |
+| [Eventbrite](https://www.eventbrite.com/developer/v3/)                                                                          | Find events                           | `OAuth`  | Yes   | Unknown |
+| [Picatic](http://developer.picatic.com/?utm_medium=web&utm_source=github&utm_campaign=public-apis%20repo&utm_content=toddmotto) | Sell tickets anywhere                 | `apiKey` | Yes   | Unknown |
+| [Ticketmaster](http://developer.ticketmaster.com/products-and-docs/apis/getting-started/)                                       | Search events, attractions, or venues | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Finance
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Alpha Vantage](https://www.alphavantage.co/) | Realtime and historical stock data | `apiKey` | Yes | Unknown |
-| [Barchart OnDemand](https://www.barchartondemand.com/free) | Stock, Futures and Forex Market Data | `apiKey` | Yes | Unknown |
-| [Consumer Financial Protection Bureau](https://data.consumerfinance.gov/resource/jhzv-w97w.json) | Financial services consumer complaint data | `apiKey` | Yes | Unknown |
-| [Financial Modeling Prep](https://financialmodelingprep.com/) | Stock information and data | No | Yes | Unknown |
-| [IEX](https://iextrading.com/developer/) | Realtime stock data | `apiKey` | Yes | Yes |
-| [IEX Cloud](https://iexcloud.io/) | Realtime & Historical Stock and Market Data | `apiKey` | Yes | Yes |
-| [IG](https://labs.ig.com/gettingstarted) | Spreadbetting and CFD Market Data | `apiKey` | Yes | Unknown |
-| [Plaid](https://plaid.com/) | Connect with users’ bank accounts and access transaction data | `apiKey` | Yes | Unknown |
-| [Razorpay IFSC](https://ifsc.razorpay.com/) | Indian Financial Systems Code (Bank Branch Codes) | No | Yes | Unknown |
-| [Repetiti](https://developers.repetiti.com/) | Repetiti 3d Printer Management Service, access and control 3d Printers easily  | `apiKey` | Yes | Yes |
-| [RoutingNumbers.info](https://www.routingnumbers.info/api/index.html) | ACH/NACHA Bank Routing Numbers | No | Yes | Unknown |
-| [Tradier](https://developer.tradier.com) | US equity/option market data (delayed, intraday, historical) | `OAuth` | Yes | Yes |
-| [VAT Rates](https://jsonvat.com/) | A collection of all VAT rates for EU countries | No | Yes | Unknown |
-| [YNAB](https://api.youneedabudget.com/) | Budgeting & Planning | `OAuth` | Yes | Yes |
+
+| API                                                                                              | Description                                                                   | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Alpha Vantage](https://www.alphavantage.co/)                                                    | Realtime and historical stock data                                            | `apiKey` | Yes   | Unknown |
+| [Barchart OnDemand](https://www.barchartondemand.com/free)                                       | Stock, Futures and Forex Market Data                                          | `apiKey` | Yes   | Unknown |
+| [Consumer Financial Protection Bureau](https://data.consumerfinance.gov/resource/jhzv-w97w.json) | Financial services consumer complaint data                                    | `apiKey` | Yes   | Unknown |
+| [Financial Modeling Prep](https://financialmodelingprep.com/)                                    | Stock information and data                                                    | No       | Yes   | Unknown |
+| [IEX](https://iextrading.com/developer/)                                                         | Realtime stock data                                                           | `apiKey` | Yes   | Yes     |
+| [IEX Cloud](https://iexcloud.io/)                                                                | Realtime & Historical Stock and Market Data                                   | `apiKey` | Yes   | Yes     |
+| [IG](https://labs.ig.com/gettingstarted)                                                         | Spreadbetting and CFD Market Data                                             | `apiKey` | Yes   | Unknown |
+| [Plaid](https://plaid.com/)                                                                      | Connect with users’ bank accounts and access transaction data                 | `apiKey` | Yes   | Unknown |
+| [Razorpay IFSC](https://ifsc.razorpay.com/)                                                      | Indian Financial Systems Code (Bank Branch Codes)                             | No       | Yes   | Unknown |
+| [Repetiti](https://developers.repetiti.com/)                                                     | Repetiti 3d Printer Management Service, access and control 3d Printers easily | `apiKey` | Yes   | Yes     |
+| [RoutingNumbers.info](https://www.routingnumbers.info/api/index.html)                            | ACH/NACHA Bank Routing Numbers                                                | No       | Yes   | Unknown |
+| [Tradier](https://developer.tradier.com)                                                         | US equity/option market data (delayed, intraday, historical)                  | `OAuth`  | Yes   | Yes     |
+| [VAT Rates](https://jsonvat.com/)                                                                | A collection of all VAT rates for EU countries                                | No       | Yes   | Unknown |
+| [YNAB](https://api.youneedabudget.com/)                                                          | Budgeting & Planning                                                          | `OAuth`  | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
+
 ### Food & Drink
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Edamam](https://developer.edamam.com/) | Recipe Search | `apiKey` | Yes | Unknown |
-| [LCBO](https://lcboapi.com/) | Alcohol | `apiKey` | Yes | Unknown |
-| [Open Brewery DB](https://www.openbrewerydb.org) | Breweries, Cideries and Craft Beer Bottle Shops | No | Yes | Yes |
-| [Open Food Facts](https://world.openfoodfacts.org/data) | Food Products Database | No | Yes | Unknown |
-| [PunkAPI](https://punkapi.com/) | Brewdog Beer Recipes | No | Yes | Unknown |
-| [Recipe Puppy](http://www.recipepuppy.com/about/api/) | Food | No | No | Unknown |
-| [TacoFancy](https://github.com/evz/tacofancy-api) | Community-driven taco database | No | No | Unknown |
-| [The Report of the Week](https://github.com/andyklimczak/TheReportOfTheWeek-API) | Food & Drink Reviews | No | Yes | Unknown |
-| [TheCocktailDB](https://www.thecocktaildb.com/api.php) | Cocktail Recipes | `apiKey` | Yes | Yes |
-| [TheMealDB](https://www.themealdb.com/api.php) | Meal Recipes | `apiKey` | Yes | Yes |
-| [What's on the menu?](http://nypl.github.io/menus-api/) | NYPL human-transcribed historical menu collection | `apiKey` | No | Unknown |
-| [Zomato](https://developers.zomato.com/api) | Discover restaurants | `apiKey` | Yes | Unknown |
+
+| API                                                                              | Description                                       | Auth     | HTTPS | CORS    |
+| -------------------------------------------------------------------------------- | ------------------------------------------------- | -------- | ----- | ------- |
+| [Edamam](https://developer.edamam.com/)                                          | Recipe Search                                     | `apiKey` | Yes   | Unknown |
+| [LCBO](https://lcboapi.com/)                                                     | Alcohol                                           | `apiKey` | Yes   | Unknown |
+| [Open Brewery DB](https://www.openbrewerydb.org)                                 | Breweries, Cideries and Craft Beer Bottle Shops   | No       | Yes   | Yes     |
+| [Open Food Facts](https://world.openfoodfacts.org/data)                          | Food Products Database                            | No       | Yes   | Unknown |
+| [PunkAPI](https://punkapi.com/)                                                  | Brewdog Beer Recipes                              | No       | Yes   | Unknown |
+| [Recipe Puppy](http://www.recipepuppy.com/about/api/)                            | Food                                              | No       | No    | Unknown |
+| [TacoFancy](https://github.com/evz/tacofancy-api)                                | Community-driven taco database                    | No       | No    | Unknown |
+| [The Report of the Week](https://github.com/andyklimczak/TheReportOfTheWeek-API) | Food & Drink Reviews                              | No       | Yes   | Unknown |
+| [TheCocktailDB](https://www.thecocktaildb.com/api.php)                           | Cocktail Recipes                                  | `apiKey` | Yes   | Yes     |
+| [TheMealDB](https://www.themealdb.com/api.php)                                   | Meal Recipes                                      | `apiKey` | Yes   | Yes     |
+| [What's on the menu?](http://nypl.github.io/menus-api/)                          | NYPL human-transcribed historical menu collection | `apiKey` | No    | Unknown |
+| [Zomato](https://developers.zomato.com/api)                                      | Discover restaurants                              | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Fraud Prevention
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [FraudLabs Pro](https://www.fraudlabspro.com/developer/api/screen-order) | Screen order information using AI to detect frauds | `apiKey` | Yes | Unknown |
-| [Whitepages Pro](https://pro.whitepages.com/developer/documentation/identity-check-api/) | Global identity verification with phone, address, email and IP | `apiKey` | Yes | Unknown |
-| [Whitepages Pro](https://pro.whitepages.com/developer/documentation/phone-reputation-api/) | Phone reputation to detect spammy phones | `apiKey` | Yes | Unknown |
-| [Whitepages Pro](https://pro.whitepages.com/developer/documentation/reverse-phone-api/) | Get an owner’s name, address, demographics based on the phone number | `apiKey` | Yes | Unknown |
-| [Whitepages Pro](https://pro.whitepages.com/developer/documentation/phone-intelligence-api/) | Phone number validation, line_type, carrier append | `apiKey` | Yes | Unknown |
-| [Whitepages Pro](https://pro.whitepages.com/developer/documentation/reverse-address-api/) | Get normalized physical address, residents, address type and validity | `apiKey` | Yes | Unknown |
+
+| API                                                                                          | Description                                                           | Auth     | HTTPS | CORS    |
+| -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------- | ----- | ------- |
+| [FraudLabs Pro](https://www.fraudlabspro.com/developer/api/screen-order)                     | Screen order information using AI to detect frauds                    | `apiKey` | Yes   | Unknown |
+| [Whitepages Pro](https://pro.whitepages.com/developer/documentation/identity-check-api/)     | Global identity verification with phone, address, email and IP        | `apiKey` | Yes   | Unknown |
+| [Whitepages Pro](https://pro.whitepages.com/developer/documentation/phone-reputation-api/)   | Phone reputation to detect spammy phones                              | `apiKey` | Yes   | Unknown |
+| [Whitepages Pro](https://pro.whitepages.com/developer/documentation/reverse-phone-api/)      | Get an owner’s name, address, demographics based on the phone number  | `apiKey` | Yes   | Unknown |
+| [Whitepages Pro](https://pro.whitepages.com/developer/documentation/phone-intelligence-api/) | Phone number validation, line_type, carrier append                    | `apiKey` | Yes   | Unknown |
+| [Whitepages Pro](https://pro.whitepages.com/developer/documentation/reverse-address-api/)    | Get normalized physical address, residents, address type and validity | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Games & Comics
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Age of Empires II](https://age-of-empires-2-api.herokuapp.com) | Get information about Age of Empires II resources | No | Yes | Unknown |
-| [AmiiboAPI](http://www.amiiboapi.com/) | Amiibo Information | No | No | Yes |
-| [Battle.net](https://dev.battle.net/) | Blizzard Entertainment | `apiKey` | Yes | Unknown |
-| [Chuck Norris Database](http://www.icndb.com/api/) | Jokes | No | No | Unknown |
-| [Clash of Clans](https://developer.clashofclans.com) | Clash of Clans Game Information | `apiKey` | Yes | Unknown |
-| [Clash Royale](https://developer.clashroyale.com) | Clash Royale Game Information | `apiKey` | Yes | Unknown |
-| [Comic Vine](https://comicvine.gamespot.com/api/documentation) | Comics | No | Yes | Unknown |
-| [Deck of Cards](http://deckofcardsapi.com/) | Deck of Cards | No | No | Unknown |
-| [Destiny The Game](https://github.com/Bungie-net/api) | Bungie Platform API | `apiKey` | Yes | Unknown |
-| [Dota 2](https://docs.opendota.com/) | Provides information about Player stats , Match stats, Rankings for Dota 2 | No | Yes | Unknown |
-| [Dungeons and Dragons](http://www.dnd5eapi.co/) | Reference for 5th edition spells, classes, monsters, and more | No | No | No |
-| [Eve Online](https://esi.evetech.net/ui) | Third-Party Developer Documentation | `OAuth` | Yes | Unknown |
-| [Final Fantasy XIV](https://xivapi.com/) | Final Fantasy XIV Game data API | No | Yes | Yes |
-| [Fortnite](https://fortniteapi.com/) | Fortnite Stats & Cosmetics | `apiKey` | Yes | Yes |
-| [Fortnite](https://fortnitetracker.com/site-api) | Fortnite Stats | `apiKey` | Yes | Unknown |
-| [Giant Bomb](https://www.giantbomb.com/api/documentation) | Video Games | No | Yes | Unknown |
-| [Guild Wars 2](https://wiki.guildwars2.com/wiki/API:Main) | Guild Wars 2 Game Information | `apiKey` | Yes | Unknown |
-| [Halo](https://developer.haloapi.com/) | Halo 5 and Halo Wars 2 Information | `apiKey` | Yes | Unknown |
-| [Hearthstone](http://hearthstoneapi.com/) | Hearthstone Cards Information | `X-Mashape-Key` | Yes | Unknown |
-| [Hypixel](https://api.hypixel.net/) | Hypixel player stats | `apiKey` | Yes | Unknown |
-| [IGDB.com](https://api.igdb.com/) | Video Game Database | `apiKey` | Yes | Unknown |
-| [JokeAPI](https://sv443.net/jokeapi) | Programming, Miscellaneous and Dark Jokes | No | Yes | Yes |
-| [Jokes](https://github.com/15Dkatz/official_joke_api) | Programming and general jokes | No | Yes | Unknown |
-| [Jservice](http://jservice.io) | Jeopardy Question Database | No | No | Unknown |
-| [Magic The Gathering](http://magicthegathering.io/) | Magic The Gathering Game Information | No | No | Unknown |
-| [Marvel](http://developer.marvel.com) | Marvel Comics | `apiKey` | No | Unknown |
-| [mod.io](https://docs.mod.io) | Cross Platform Mod API | `apiKey` | Yes | Unknown |
-| [Open Trivia](https://opentdb.com/api_config.php) | Trivia Questions | No | Yes | Unknown |
-| [PandaScore](https://api.pandascore.co) | E-sports games and results | `apiKey` | Yes | Unknown |
-| [PlayerUnknown's Battlegrounds](https://pubgtracker.com/site-api) | PUBG Stats | `apiKey` | Yes | Unknown |
-| [Pokéapi](https://pokeapi.co) | Pokémon Information | No | Yes | Unknown |
-| [Pokémon TCG](https://pokemontcg.io) | Pokémon TCG Information | No | Yes | Unknown |
-| [Rick and Morty](https://rickandmortyapi.com) | All the Rick and Morty information, including images | No | Yes | Yes |
-| [Riot Games](https://developer.riotgames.com/) | League of Legends Game Information | `apiKey` | Yes | Unknown |
-| [Scryfall](https://scryfall.com/docs/api) | Magic: The Gathering database | No | Yes | Yes |
-| [Steam](https://developer.valvesoftware.com/wiki/Steam_Web_API) | Steam Client Interaction | `OAuth` | Yes | Unknown |
-| [SuperHeroes](https://superheroapi.com) | All SuperHeroes and Villains data from all universes under a single API | `apiKey` | Yes | Unknown |
-| [Tronald Dump](https://www.tronalddump.io/) | The dumbest things Donald Trump has ever said | No | Yes | Unknown |
-| [Vainglory](https://developer.vainglorygame.com/) | Vainglory Players, Matches and Telemetry | `apiKey` | Yes | Yes |
-| [Wargaming.net](https://developers.wargaming.net/) | Wargaming.net info and stats | `apiKey` | Yes | No |
-| [xkcd](https://xkcd.com/json.html) | Retrieve xkcd comics as JSON | No | Yes | No |
+
+| API                                                               | Description                                                                | Auth            | HTTPS | CORS    |
+| ----------------------------------------------------------------- | -------------------------------------------------------------------------- | --------------- | ----- | ------- |
+| [Age of Empires II](https://age-of-empires-2-api.herokuapp.com)   | Get information about Age of Empires II resources                          | No              | Yes   | Unknown |
+| [AmiiboAPI](http://www.amiiboapi.com/)                            | Amiibo Information                                                         | No              | No    | Yes     |
+| [Battle.net](https://dev.battle.net/)                             | Blizzard Entertainment                                                     | `apiKey`        | Yes   | Unknown |
+| [Chuck Norris Database](http://www.icndb.com/api/)                | Jokes                                                                      | No              | No    | Unknown |
+| [Clash of Clans](https://developer.clashofclans.com)              | Clash of Clans Game Information                                            | `apiKey`        | Yes   | Unknown |
+| [Clash Royale](https://developer.clashroyale.com)                 | Clash Royale Game Information                                              | `apiKey`        | Yes   | Unknown |
+| [Comic Vine](https://comicvine.gamespot.com/api/documentation)    | Comics                                                                     | No              | Yes   | Unknown |
+| [Deck of Cards](http://deckofcardsapi.com/)                       | Deck of Cards                                                              | No              | No    | Unknown |
+| [Destiny The Game](https://github.com/Bungie-net/api)             | Bungie Platform API                                                        | `apiKey`        | Yes   | Unknown |
+| [Dota 2](https://docs.opendota.com/)                              | Provides information about Player stats , Match stats, Rankings for Dota 2 | No              | Yes   | Unknown |
+| [Dungeons and Dragons](http://www.dnd5eapi.co/)                   | Reference for 5th edition spells, classes, monsters, and more              | No              | No    | No      |
+| [Eve Online](https://esi.evetech.net/ui)                          | Third-Party Developer Documentation                                        | `OAuth`         | Yes   | Unknown |
+| [Final Fantasy XIV](https://xivapi.com/)                          | Final Fantasy XIV Game data API                                            | No              | Yes   | Yes     |
+| [Fortnite](https://fortniteapi.com/)                              | Fortnite Stats & Cosmetics                                                 | `apiKey`        | Yes   | Yes     |
+| [Fortnite](https://fortnitetracker.com/site-api)                  | Fortnite Stats                                                             | `apiKey`        | Yes   | Unknown |
+| [Giant Bomb](https://www.giantbomb.com/api/documentation)         | Video Games                                                                | No              | Yes   | Unknown |
+| [Guild Wars 2](https://wiki.guildwars2.com/wiki/API:Main)         | Guild Wars 2 Game Information                                              | `apiKey`        | Yes   | Unknown |
+| [Halo](https://developer.haloapi.com/)                            | Halo 5 and Halo Wars 2 Information                                         | `apiKey`        | Yes   | Unknown |
+| [Hearthstone](http://hearthstoneapi.com/)                         | Hearthstone Cards Information                                              | `X-Mashape-Key` | Yes   | Unknown |
+| [Hypixel](https://api.hypixel.net/)                               | Hypixel player stats                                                       | `apiKey`        | Yes   | Unknown |
+| [IGDB.com](https://api.igdb.com/)                                 | Video Game Database                                                        | `apiKey`        | Yes   | Unknown |
+| [JokeAPI](https://sv443.net/jokeapi)                              | Programming, Miscellaneous and Dark Jokes                                  | No              | Yes   | Yes     |
+| [Jokes](https://github.com/15Dkatz/official_joke_api)             | Programming and general jokes                                              | No              | Yes   | Unknown |
+| [Jservice](http://jservice.io)                                    | Jeopardy Question Database                                                 | No              | No    | Unknown |
+| [Magic The Gathering](http://magicthegathering.io/)               | Magic The Gathering Game Information                                       | No              | No    | Unknown |
+| [Marvel](http://developer.marvel.com)                             | Marvel Comics                                                              | `apiKey`        | No    | Unknown |
+| [mod.io](https://docs.mod.io)                                     | Cross Platform Mod API                                                     | `apiKey`        | Yes   | Unknown |
+| [Open Trivia](https://opentdb.com/api_config.php)                 | Trivia Questions                                                           | No              | Yes   | Unknown |
+| [PandaScore](https://api.pandascore.co)                           | E-sports games and results                                                 | `apiKey`        | Yes   | Unknown |
+| [PlayerUnknown's Battlegrounds](https://pubgtracker.com/site-api) | PUBG Stats                                                                 | `apiKey`        | Yes   | Unknown |
+| [Pokéapi](https://pokeapi.co)                                     | Pokémon Information                                                        | No              | Yes   | Unknown |
+| [Pokémon TCG](https://pokemontcg.io)                              | Pokémon TCG Information                                                    | No              | Yes   | Unknown |
+| [Rick and Morty](https://rickandmortyapi.com)                     | All the Rick and Morty information, including images                       | No              | Yes   | Yes     |
+| [Riot Games](https://developer.riotgames.com/)                    | League of Legends Game Information                                         | `apiKey`        | Yes   | Unknown |
+| [Scryfall](https://scryfall.com/docs/api)                         | Magic: The Gathering database                                              | No              | Yes   | Yes     |
+| [Steam](https://developer.valvesoftware.com/wiki/Steam_Web_API)   | Steam Client Interaction                                                   | `OAuth`         | Yes   | Unknown |
+| [SuperHeroes](https://superheroapi.com)                           | All SuperHeroes and Villains data from all universes under a single API    | `apiKey`        | Yes   | Unknown |
+| [Tronald Dump](https://www.tronalddump.io/)                       | The dumbest things Donald Trump has ever said                              | No              | Yes   | Unknown |
+| [Vainglory](https://developer.vainglorygame.com/)                 | Vainglory Players, Matches and Telemetry                                   | `apiKey`        | Yes   | Yes     |
+| [Wargaming.net](https://developers.wargaming.net/)                | Wargaming.net info and stats                                               | `apiKey`        | Yes   | No      |
+| [xkcd](https://xkcd.com/json.html)                                | Retrieve xkcd comics as JSON                                               | No              | Yes   | No      |
 
 **[⬆ Back to Index](#index)**
+
 ### Geocoding
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [adresse.data.gouv.fr](https://adresse.data.gouv.fr) | Address database of France, geocoding and reverse | No | Yes | Unknown |
-| [Battuta](http://battuta.medunes.net) | A (country/region/city) in-cascade location API | `apiKey` | No | Unknown |
-| [BigDataCloud](https://www.bigdatacloud.com/ip-geolocation-apis) | Provides fast and accurate IP geolocation APIs along with security checks and confidence area | `apiKey` | Yes | Unknown |
-| [Bing Maps](https://www.microsoft.com/maps/) | Create/customize digital maps based on Bing Maps data | `apiKey` | Yes | Unknown |
-| [bng2latlong](https://www.getthedata.com/bng2latlong) | Convert British OSGB36 easting and northing (British National Grid) to WGS84 latitude and longitude | No | Yes | Yes |
-| [CitySDK](http://www.citysdk.eu/citysdk-toolkit/) | Open APIs for select European cities | No | Yes | Unknown |
-| [Daum Maps](http://apis.map.daum.net/) | Daum Maps provide multiple APIs for Korean maps | `apiKey` | No | Unknown |
-| [FreeGeoIP](https://freegeoip.app/) | Free geo ip information, no registration required. 15k/hour rate limit | No | Yes | Yes |
-| [GeoApi](https://api.gouv.fr/api/geoapi.html) | French geographical data | No | Yes | Unknown |
-| [Geocod.io](https://www.geocod.io/) | Address geocoding / reverse geocoding in bulk | `apiKey` | Yes | Unknown |
-| [Geocode.xyz](https://geocode.xyz/) | Provides worldwide forward/reverse geocoding, batch geocoding and geoparsing | No | Yes | Unknown |
-| [GeoDataSource](https://www.geodatasource.com/web-service) | Geocoding of city name by using latitude and longitude coordinates | `apiKey` | Yes | Unknown |
-| [GeoJS](https://geojs.io/) | IP geolocation with ChatOps integration | No | Yes | Yes |
-| [GeoNames](http://www.geonames.org/export/web-services.html) | Place names and other geographical data | No | No | Unknown |
-| [geoPlugin](https://www.geoplugin.com) | IP geolocation and currency conversion | No | Yes | Yes |
-| [Google Earth Engine](https://developers.google.com/earth-engine/) | A cloud-based platform for planetary-scale environmental data analysis | `apiKey` | Yes | Unknown |
-| [Google Maps](https://developers.google.com/maps/) | Create/customize digital maps based on Google Maps data | `apiKey` | Yes | Unknown |
-| [HelloSalut](https://www.fourtonfish.com/hellosalut/hello/) | Get hello translation following user language | No | Yes | Unknown |
-| [HERE Maps](https://developer.here.com) | Create/customize digital maps based on HERE Maps data | `apiKey` | Yes | Unknown |
-| [Indian Cities](https://indian-cities-api-nocbegfhqg.now.sh/) | Get all Indian cities in a clean JSON Format | No | Yes | Yes |
-| [IP 2 Country](https://ip2country.info) | Map an IP to a country | No | Yes | Unknown |
-| [IP Address Details](https://ipinfo.io/) | Find geolocation with ip address | No | Yes | Unknown |
-| [IP Location](http://ip-api.com/) | Find location with ip address | No | No | Unknown |
-| [IP Location](https://ipapi.co/) | Find IP address location information | No | Yes | Unknown |
-| [IP Sidekick](https://ipsidekick.com) | Geolocation API that returns extra information about an IP address | `apiKey` | Yes | Unknown |
-| [IP Vigilante](https://www.ipvigilante.com/) | Free IP Geolocation API | No | Yes | Unknown |
-| [IP2Location](https://www.ip2location.com/web-service/ip2location) | IP geolocation web service to get more than 55 parameters | `apiKey` | Yes | Unknown |
-| [IP2Proxy](https://www.ip2location.com/web-service/ip2proxy) | Detect proxy and VPN using IP address | `apiKey` | Yes | Unknown |
-| [IPGeolocationAPI.com](https://ipgeolocationapi.com/) | Locate your visitors by IP with country details | No | Yes | Yes |
-| [IPInfoDB](https://ipinfodb.com/api) | Free Geolocation tools and APIs for country, region, city and time zone lookup by IP address | `apiKey` | Yes | Unknown |
-| [ipstack](https://ipstack.com/) | Locate and identify website visitors by IP address | `apiKey` | Yes | Unknown |
-| [Kwelo Network](https://www.kwelo.com/network/ip-address) | Locate and get detailed information on IP address | No | Yes | Yes |
-| [LocationIQ](https://locationiq.org/docs/) | Provides forward/reverse geocoding and batch geocoding | `apiKey` | Yes | Yes |
-| [Mapbox](https://www.mapbox.com/developers/) | Create/customize beautiful digital maps | `apiKey` | Yes | Unknown |
-| [Mexico](https://github.com/IcaliaLabs/sepomex) | Mexico RESTful zip codes API | No | Yes | Unknown |
-| [One Map, Singapore](https://docs.onemap.sg/) | Singapore Land Authority REST API services for Singapore addresses | `apiKey` | Yes | Unknown |
-| [OnWater](https://onwater.io/) | Determine if a lat/lon is on water or land | No | Yes | Unknown |
-| [OpenCage](https://opencagedata.com) | Forward and reverse geocoding using open data | `apiKey` | Yes | Yes |
-| [OpenStreetMap](http://wiki.openstreetmap.org/wiki/API) | Navigation, geolocation and geographical data | `OAuth` | No | Unknown |
-| [PostcodeData.nl](http://api.postcodedata.nl/v1/postcode/?postcode=1211EP&streetnumber=60&ref=domeinnaam.nl&type=json) | Provide geolocation data based on postcode for Dutch addresses | No | No | Unknown |
-| [Postcodes.io](https://postcodes.io) | Postcode lookup & Geolocation for the UK | No | Yes | Yes |
-| [REST Countries](https://restcountries.eu) | Get information about countries via a RESTful API | No | Yes | Unknown |
-| [SmartIP.io](https://smartip.io) | IP Geolocation and Threat Intelligence API | `apiKey` | Yes | Yes |
-| [Uebermaps](https://uebermaps.com/api/v2) | Discover and share maps with friends | `apiKey` | Yes | Unknown |
-| [US ZipCode](https://smartystreets.com/docs/cloud/us-zipcode-api) | Validate and append data for any US ZipCode | `apiKey` | Yes | Yes |
-| [Utah AGRC](https://api.mapserv.utah.gov) | Utah Web API for geocoding Utah addresses | `apiKey` | Yes | Unknown |
-| [ViaCep](https://viacep.com.br) | Brazil RESTful zip codes API | No | Yes | Unknown |
-| [ZipCodeAPI](https://www.zipcodeapi.com) | US zip code distance, radius and location API | `apiKey` | Yes | Unknown |
-| [Zippopotam](http://www.zippopotam.us) | Get information about place such as country, city, state, etc | No | No | Unknown |
+
+| API                                                                                                                    | Description                                                                                         | Auth     | HTTPS | CORS    |
+| ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [adresse.data.gouv.fr](https://adresse.data.gouv.fr)                                                                   | Address database of France, geocoding and reverse                                                   | No       | Yes   | Unknown |
+| [Battuta](http://battuta.medunes.net)                                                                                  | A (country/region/city) in-cascade location API                                                     | `apiKey` | No    | Unknown |
+| [BigDataCloud](https://www.bigdatacloud.com/ip-geolocation-apis)                                                       | Provides fast and accurate IP geolocation APIs along with security checks and confidence area       | `apiKey` | Yes   | Unknown |
+| [Bing Maps](https://www.microsoft.com/maps/)                                                                           | Create/customize digital maps based on Bing Maps data                                               | `apiKey` | Yes   | Unknown |
+| [bng2latlong](https://www.getthedata.com/bng2latlong)                                                                  | Convert British OSGB36 easting and northing (British National Grid) to WGS84 latitude and longitude | No       | Yes   | Yes     |
+| [CitySDK](http://www.citysdk.eu/citysdk-toolkit/)                                                                      | Open APIs for select European cities                                                                | No       | Yes   | Unknown |
+| [Daum Maps](http://apis.map.daum.net/)                                                                                 | Daum Maps provide multiple APIs for Korean maps                                                     | `apiKey` | No    | Unknown |
+| [FreeGeoIP](https://freegeoip.app/)                                                                                    | Free geo ip information, no registration required. 15k/hour rate limit                              | No       | Yes   | Yes     |
+| [GeoApi](https://api.gouv.fr/api/geoapi.html)                                                                          | French geographical data                                                                            | No       | Yes   | Unknown |
+| [Geocod.io](https://www.geocod.io/)                                                                                    | Address geocoding / reverse geocoding in bulk                                                       | `apiKey` | Yes   | Unknown |
+| [Geocode.xyz](https://geocode.xyz/)                                                                                    | Provides worldwide forward/reverse geocoding, batch geocoding and geoparsing                        | No       | Yes   | Unknown |
+| [GeoDataSource](https://www.geodatasource.com/web-service)                                                             | Geocoding of city name by using latitude and longitude coordinates                                  | `apiKey` | Yes   | Unknown |
+| [GeoJS](https://geojs.io/)                                                                                             | IP geolocation with ChatOps integration                                                             | No       | Yes   | Yes     |
+| [GeoNames](http://www.geonames.org/export/web-services.html)                                                           | Place names and other geographical data                                                             | No       | No    | Unknown |
+| [geoPlugin](https://www.geoplugin.com)                                                                                 | IP geolocation and currency conversion                                                              | No       | Yes   | Yes     |
+| [Google Earth Engine](https://developers.google.com/earth-engine/)                                                     | A cloud-based platform for planetary-scale environmental data analysis                              | `apiKey` | Yes   | Unknown |
+| [Google Maps](https://developers.google.com/maps/)                                                                     | Create/customize digital maps based on Google Maps data                                             | `apiKey` | Yes   | Unknown |
+| [HelloSalut](https://www.fourtonfish.com/hellosalut/hello/)                                                            | Get hello translation following user language                                                       | No       | Yes   | Unknown |
+| [HERE Maps](https://developer.here.com)                                                                                | Create/customize digital maps based on HERE Maps data                                               | `apiKey` | Yes   | Unknown |
+| [Indian Cities](https://indian-cities-api-nocbegfhqg.now.sh/)                                                          | Get all Indian cities in a clean JSON Format                                                        | No       | Yes   | Yes     |
+| [IP 2 Country](https://ip2country.info)                                                                                | Map an IP to a country                                                                              | No       | Yes   | Unknown |
+| [IP Address Details](https://ipinfo.io/)                                                                               | Find geolocation with ip address                                                                    | No       | Yes   | Unknown |
+| [IP Location](http://ip-api.com/)                                                                                      | Find location with ip address                                                                       | No       | No    | Unknown |
+| [IP Location](https://ipapi.co/)                                                                                       | Find IP address location information                                                                | No       | Yes   | Unknown |
+| [IP Sidekick](https://ipsidekick.com)                                                                                  | Geolocation API that returns extra information about an IP address                                  | `apiKey` | Yes   | Unknown |
+| [IP Vigilante](https://www.ipvigilante.com/)                                                                           | Free IP Geolocation API                                                                             | No       | Yes   | Unknown |
+| [IP2Location](https://www.ip2location.com/web-service/ip2location)                                                     | IP geolocation web service to get more than 55 parameters                                           | `apiKey` | Yes   | Unknown |
+| [IP2Proxy](https://www.ip2location.com/web-service/ip2proxy)                                                           | Detect proxy and VPN using IP address                                                               | `apiKey` | Yes   | Unknown |
+| [IPGeolocationAPI.com](https://ipgeolocationapi.com/)                                                                  | Locate your visitors by IP with country details                                                     | No       | Yes   | Yes     |
+| [IPInfoDB](https://ipinfodb.com/api)                                                                                   | Free Geolocation tools and APIs for country, region, city and time zone lookup by IP address        | `apiKey` | Yes   | Unknown |
+| [ipstack](https://ipstack.com/)                                                                                        | Locate and identify website visitors by IP address                                                  | `apiKey` | Yes   | Unknown |
+| [Kwelo Network](https://www.kwelo.com/network/ip-address)                                                              | Locate and get detailed information on IP address                                                   | No       | Yes   | Yes     |
+| [LocationIQ](https://locationiq.org/docs/)                                                                             | Provides forward/reverse geocoding and batch geocoding                                              | `apiKey` | Yes   | Yes     |
+| [Mapbox](https://www.mapbox.com/developers/)                                                                           | Create/customize beautiful digital maps                                                             | `apiKey` | Yes   | Unknown |
+| [Mexico](https://github.com/IcaliaLabs/sepomex)                                                                        | Mexico RESTful zip codes API                                                                        | No       | Yes   | Unknown |
+| [One Map, Singapore](https://docs.onemap.sg/)                                                                          | Singapore Land Authority REST API services for Singapore addresses                                  | `apiKey` | Yes   | Unknown |
+| [OnWater](https://onwater.io/)                                                                                         | Determine if a lat/lon is on water or land                                                          | No       | Yes   | Unknown |
+| [OpenCage](https://opencagedata.com)                                                                                   | Forward and reverse geocoding using open data                                                       | `apiKey` | Yes   | Yes     |
+| [OpenStreetMap](http://wiki.openstreetmap.org/wiki/API)                                                                | Navigation, geolocation and geographical data                                                       | `OAuth`  | No    | Unknown |
+| [PostcodeData.nl](http://api.postcodedata.nl/v1/postcode/?postcode=1211EP&streetnumber=60&ref=domeinnaam.nl&type=json) | Provide geolocation data based on postcode for Dutch addresses                                      | No       | No    | Unknown |
+| [Postcodes.io](https://postcodes.io)                                                                                   | Postcode lookup & Geolocation for the UK                                                            | No       | Yes   | Yes     |
+| [REST Countries](https://restcountries.eu)                                                                             | Get information about countries via a RESTful API                                                   | No       | Yes   | Unknown |
+| [SmartIP.io](https://smartip.io)                                                                                       | IP Geolocation and Threat Intelligence API                                                          | `apiKey` | Yes   | Yes     |
+| [Uebermaps](https://uebermaps.com/api/v2)                                                                              | Discover and share maps with friends                                                                | `apiKey` | Yes   | Unknown |
+| [US ZipCode](https://smartystreets.com/docs/cloud/us-zipcode-api)                                                      | Validate and append data for any US ZipCode                                                         | `apiKey` | Yes   | Yes     |
+| [Utah AGRC](https://api.mapserv.utah.gov)                                                                              | Utah Web API for geocoding Utah addresses                                                           | `apiKey` | Yes   | Unknown |
+| [ViaCep](https://viacep.com.br)                                                                                        | Brazil RESTful zip codes API                                                                        | No       | Yes   | Unknown |
+| [ZipCodeAPI](https://www.zipcodeapi.com)                                                                               | US zip code distance, radius and location API                                                       | `apiKey` | Yes   | Unknown |
+| [Zippopotam](http://www.zippopotam.us)                                                                                 | Get information about place such as country, city, state, etc                                       | No       | No    | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Government
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [BCLaws](http://www.bclaws.ca/civix/template/complete/api/index.html) | Access to the laws of British Columbia | No | No | Unknown |
-| [BusinessUSA](https://business.usa.gov/developer) | Authoritative information on U.S. programs, events, services and more | `apiKey` | Yes | Unknown |
-| [Census.gov](https://www.census.gov/data/developers/data-sets.html) | The US Census Bureau provides various APIs and data sets on demographics and businesses | No | Yes | Unknown |
-| [City, Lyon Opendata](https://data.beta.grandlyon.com/fr/accueil) | Lyon(FR) City Open Data | `apiKey` | Yes | Unknown |
-| [City, Nantes Opendata](https://data.nantesmetropole.fr/pages/home/) | Nantes(FR) City Open Data | `apiKey` | Yes | Unknown |
-| [City, Prague Opendata](http://opendata.praha.eu/en) | Prague(CZ) City Open Data | No | No | Unknown |
-| [Code.gov](https://code.gov) | The primary platform for Open Source and code sharing for the U.S. Federal Government | `apiKey` | Yes | Unknown |
-| [Colorado Data Engine](http://codataengine.org/) | Formatted and geolocated Colorado public data | No | Yes | Unknown |
-| [Colorado Information Marketplace](https://data.colorado.gov/) | Colorado State Government Open Data | No | Yes | Unknown |
-| [Data USA](https://datausa.io/about/api/) | US Public Data | No | Yes | Unknown |
-| [Data.gov](https://api.data.gov/) | US Government Data | `apiKey` | Yes | Unknown |
-| [Data.parliament.uk](http://www.data.parliament.uk/developers/) | Contains live datasets including information about petitions, bills, MP votes, attendance and more | No | No | Unknown |
-| [District of Columbia Open Data](http://opendata.dc.gov/pages/using-apis) | Contains D.C. government public datasets, including crime, GIS, financial data, and so on | No | Yes | Unknown |
-| [EPA](https://developer.epa.gov/category/apis/) | Web services and data sets from the US Environmental Protection Agency | No | Yes | Unknown |
-| [FEC](https://api.open.fec.gov/developers/) | Information on campaign donations in federal elections | `apiKey` | Yes | Unknown |
-| [Federal Register](https://www.federalregister.gov/reader-aids/developer-resources) | The Daily Journal of the United States Government | No | Yes | Unknown |
-| [Food Standards Agency](http://ratings.food.gov.uk/open-data/en-GB) | UK food hygiene rating data API | No | No | Unknown |
-| [Open Government, Australia](https://www.data.gov.au/) | Australian Government Open Data | No | Yes | Unknown |
-| [Open Government, Belgium](https://data.gov.be/) | Belgium Government Open Data | No | Yes | Unknown |
-| [Open Government, Canada](http://open.canada.ca/en) | Canadian Government Open Data | No | No | Unknown |
-| [Open Government, France](https://www.data.gouv.fr/) | French Government Open Data | `apiKey` | Yes | Unknown |
-| [Open Government, India](https://data.gov.in/) | Indian Government Open Data | `apiKey` | Yes | Unknown |
-| [Open Government, Italy](https://www.dati.gov.it/) | Italy Government Open Data | No | Yes | Unknown |
-| [Open Government, New Zealand](https://www.data.govt.nz/) | New Zealand Government Open Data | No | Yes | Unknown |
-| [Open Government, Romania](http://data.gov.ro/) | Romania Government Open Data | No | No | Unknown |
-| [Open Government, Taiwan](https://data.gov.tw/) | Taiwan Government Open Data | No | Yes | Unknown |
-| [Open Government, USA](https://www.data.gov/) | United States Government Open Data | No | Yes | Unknown |
-| [Regulations.gov](https://regulationsgov.github.io/developers/) | Federal regulatory materials to increase understanding of the Federal rule making process | `apiKey` | Yes | Unknown |
-| [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
-| [USAspending.gov](https://api.usaspending.gov/) | US federal spending data | No | Yes | Unknown |
+
+| API                                                                                 | Description                                                                                        | Auth     | HTTPS | CORS    |
+| ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [BCLaws](http://www.bclaws.ca/civix/template/complete/api/index.html)               | Access to the laws of British Columbia                                                             | No       | No    | Unknown |
+| [BusinessUSA](https://business.usa.gov/developer)                                   | Authoritative information on U.S. programs, events, services and more                              | `apiKey` | Yes   | Unknown |
+| [Census.gov](https://www.census.gov/data/developers/data-sets.html)                 | The US Census Bureau provides various APIs and data sets on demographics and businesses            | No       | Yes   | Unknown |
+| [City, Lyon Opendata](https://data.beta.grandlyon.com/fr/accueil)                   | Lyon(FR) City Open Data                                                                            | `apiKey` | Yes   | Unknown |
+| [City, Nantes Opendata](https://data.nantesmetropole.fr/pages/home/)                | Nantes(FR) City Open Data                                                                          | `apiKey` | Yes   | Unknown |
+| [City, Prague Opendata](http://opendata.praha.eu/en)                                | Prague(CZ) City Open Data                                                                          | No       | No    | Unknown |
+| [Code.gov](https://code.gov)                                                        | The primary platform for Open Source and code sharing for the U.S. Federal Government              | `apiKey` | Yes   | Unknown |
+| [Colorado Data Engine](http://codataengine.org/)                                    | Formatted and geolocated Colorado public data                                                      | No       | Yes   | Unknown |
+| [Colorado Information Marketplace](https://data.colorado.gov/)                      | Colorado State Government Open Data                                                                | No       | Yes   | Unknown |
+| [Data USA](https://datausa.io/about/api/)                                           | US Public Data                                                                                     | No       | Yes   | Unknown |
+| [Data.gov](https://api.data.gov/)                                                   | US Government Data                                                                                 | `apiKey` | Yes   | Unknown |
+| [Data.parliament.uk](http://www.data.parliament.uk/developers/)                     | Contains live datasets including information about petitions, bills, MP votes, attendance and more | No       | No    | Unknown |
+| [District of Columbia Open Data](http://opendata.dc.gov/pages/using-apis)           | Contains D.C. government public datasets, including crime, GIS, financial data, and so on          | No       | Yes   | Unknown |
+| [EPA](https://developer.epa.gov/category/apis/)                                     | Web services and data sets from the US Environmental Protection Agency                             | No       | Yes   | Unknown |
+| [FEC](https://api.open.fec.gov/developers/)                                         | Information on campaign donations in federal elections                                             | `apiKey` | Yes   | Unknown |
+| [Federal Register](https://www.federalregister.gov/reader-aids/developer-resources) | The Daily Journal of the United States Government                                                  | No       | Yes   | Unknown |
+| [Food Standards Agency](http://ratings.food.gov.uk/open-data/en-GB)                 | UK food hygiene rating data API                                                                    | No       | No    | Unknown |
+| [Open Government, Australia](https://www.data.gov.au/)                              | Australian Government Open Data                                                                    | No       | Yes   | Unknown |
+| [Open Government, Belgium](https://data.gov.be/)                                    | Belgium Government Open Data                                                                       | No       | Yes   | Unknown |
+| [Open Government, Canada](http://open.canada.ca/en)                                 | Canadian Government Open Data                                                                      | No       | No    | Unknown |
+| [Open Government, France](https://www.data.gouv.fr/)                                | French Government Open Data                                                                        | `apiKey` | Yes   | Unknown |
+| [Open Government, India](https://data.gov.in/)                                      | Indian Government Open Data                                                                        | `apiKey` | Yes   | Unknown |
+| [Open Government, Italy](https://www.dati.gov.it/)                                  | Italy Government Open Data                                                                         | No       | Yes   | Unknown |
+| [Open Government, New Zealand](https://www.data.govt.nz/)                           | New Zealand Government Open Data                                                                   | No       | Yes   | Unknown |
+| [Open Government, Romania](http://data.gov.ro/)                                     | Romania Government Open Data                                                                       | No       | No    | Unknown |
+| [Open Government, Taiwan](https://data.gov.tw/)                                     | Taiwan Government Open Data                                                                        | No       | Yes   | Unknown |
+| [Open Government, USA](https://www.data.gov/)                                       | United States Government Open Data                                                                 | No       | Yes   | Unknown |
+| [Regulations.gov](https://regulationsgov.github.io/developers/)                     | Federal regulatory materials to increase understanding of the Federal rule making process          | `apiKey` | Yes   | Unknown |
+| [Represent by Open North](https://represent.opennorth.ca/)                          | Find Canadian Government Representatives                                                           | No       | Yes   | Unknown |
+| [USAspending.gov](https://api.usaspending.gov/)                                     | US federal spending data                                                                           | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Health
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [BetterDoctor](https://developer.betterdoctor.com/) | Detailed information about doctors in your area | `apiKey` | Yes | Unknown |
-| [Covid-19](https://covid19api.com/) | Covid 19 spread, infection and recovery | No | Yes | Yes |
-| [Diabetes](http://predictbgl.com/api/) | Logging and retrieving diabetes information | No | No | Unknown |
-| [Flutrack](http://www.flutrack.org/) | Influenza-like symptoms with geotracking | No | No | Unknown |
-| [Healthcare.gov](https://www.healthcare.gov/developers/) | Educational content about the US Health Insurance Marketplace | No | Yes | Unknown |
-| [Lexigram](https://docs.lexigram.io/v1/welcome) | NLP that extracts mentions of clinical concepts from text, gives access to clinical ontology | `apiKey` | Yes | Unknown |
-| [Makeup](http://makeup-api.herokuapp.com/) | Makeup Information | No | No | Unknown |
-| [Medicare](https://data.medicare.gov/developers) | Access to the data from the CMS - medicare.gov | No | Yes | Unknown |
-| [NPPES](https://npiregistry.cms.hhs.gov/registry/help-api) | National Plan & Provider Enumeration System, info on healthcare providers registered in US | No | Yes | Unknown |
-| [Nutritionix](https://developer.nutritionix.com/) | Worlds largest verified nutrition database | `apiKey` | Yes | Unknown |
-| [openFDA](https://open.fda.gov) | Public FDA data about drugs, devices and foods | No | Yes | Unknown |
-| [USDA Nutrients](https://ndb.nal.usda.gov/ndb/doc/index) | National Nutrient Database for Standard Reference | No | Yes | Unknown |
+
+| API                                                        | Description                                                                                  | Auth     | HTTPS | CORS    |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [BetterDoctor](https://developer.betterdoctor.com/)        | Detailed information about doctors in your area                                              | `apiKey` | Yes   | Unknown |
+| [Covid-19](https://covid19api.com/)                        | Covid 19 spread, infection and recovery                                                      | No       | Yes   | Yes     |
+| [Diabetes](http://predictbgl.com/api/)                     | Logging and retrieving diabetes information                                                  | No       | No    | Unknown |
+| [Flutrack](http://www.flutrack.org/)                       | Influenza-like symptoms with geotracking                                                     | No       | No    | Unknown |
+| [Healthcare.gov](https://www.healthcare.gov/developers/)   | Educational content about the US Health Insurance Marketplace                                | No       | Yes   | Unknown |
+| [Lexigram](https://docs.lexigram.io/v1/welcome)            | NLP that extracts mentions of clinical concepts from text, gives access to clinical ontology | `apiKey` | Yes   | Unknown |
+| [Makeup](http://makeup-api.herokuapp.com/)                 | Makeup Information                                                                           | No       | No    | Unknown |
+| [Medicare](https://data.medicare.gov/developers)           | Access to the data from the CMS - medicare.gov                                               | No       | Yes   | Unknown |
+| [NPPES](https://npiregistry.cms.hhs.gov/registry/help-api) | National Plan & Provider Enumeration System, info on healthcare providers registered in US   | No       | Yes   | Unknown |
+| [Nutritionix](https://developer.nutritionix.com/)          | Worlds largest verified nutrition database                                                   | `apiKey` | Yes   | Unknown |
+| [openFDA](https://open.fda.gov)                            | Public FDA data about drugs, devices and foods                                               | No       | Yes   | Unknown |
+| [USDA Nutrients](https://ndb.nal.usda.gov/ndb/doc/index)   | National Nutrient Database for Standard Reference                                            | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Jobs
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Adzuna](https://developer.adzuna.com/overview) | Job board aggregator | `apiKey` | Yes | Unknown |
-| [Authentic Jobs](https://authenticjobs.com/api/docs) | Job board for designers, hackers and creative pros | `apiKey` | Yes | Unknown |
-| [Careerjet](https://www.careerjet.com/partners/api/) | Job search engine | `apiKey` | No | Unknown |
-| [Github Jobs](https://jobs.github.com/api) | Jobs for software developers | No | Yes | Yes |
-| [GraphQL Jobs](https://api.graphql.jobs) | Jobs with GraphQL | No | Yes | Yes |
-| [Indeed](https://www.indeed.com/publisher) | Job board aggregator | `apiKey` | Yes | Unknown |
-| [Jobs2Careers](http://api.jobs2careers.com/api/spec.pdf) | Job aggregator | `apiKey` | Yes | Unknown |
-| [Jooble](https://us.jooble.org/api/about) | Job search engine | `apiKey` | Yes | Unknown |
-| [Juju](http://www.juju.com/publisher/spec/) | Job search engine | `apiKey` | No | Unknown |
-| [Open Skills](https://github.com/workforce-data-initiative/skills-api/wiki/API-Overview) | Job titles, skills and related jobs data | No | No | Unknown |
-| [Reed](https://www.reed.co.uk/developers) | Job board aggregator | `apiKey` | Yes | Unknown |
-| [Search.gov Jobs](https://search.gov/developer/jobs.html) | Tap into a list of current jobs openings with the United States government | No | Yes | Unknown |
-| [The Muse](https://www.themuse.com/developers/api/v2) | Job board and company profiles | `apiKey` | Yes | Unknown |
-| [Upwork](https://developers.upwork.com/) | Freelance job board and management system | `OAuth` | Yes | Unknown |
-| [USAJOBS](https://developer.usajobs.gov/) | US government job board | `apiKey` | Yes | Unknown |
-| [ZipRecruiter](https://www.ziprecruiter.com/publishers) | Job search app and website | `apiKey` | Yes | Unknown |
+
+| API                                                                                      | Description                                                                | Auth     | HTTPS | CORS    |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Adzuna](https://developer.adzuna.com/overview)                                          | Job board aggregator                                                       | `apiKey` | Yes   | Unknown |
+| [Authentic Jobs](https://authenticjobs.com/api/docs)                                     | Job board for designers, hackers and creative pros                         | `apiKey` | Yes   | Unknown |
+| [Careerjet](https://www.careerjet.com/partners/api/)                                     | Job search engine                                                          | `apiKey` | No    | Unknown |
+| [GraphQL Jobs](https://api.graphql.jobs)                                                 | Jobs with GraphQL                                                          | No       | Yes   | Yes     |
+| [Indeed](https://www.indeed.com/publisher)                                               | Job board aggregator                                                       | `apiKey` | Yes   | Unknown |
+| [Jobs2Careers](http://api.jobs2careers.com/api/spec.pdf)                                 | Job aggregator                                                             | `apiKey` | Yes   | Unknown |
+| [Jooble](https://us.jooble.org/api/about)                                                | Job search engine                                                          | `apiKey` | Yes   | Unknown |
+| [Juju](http://www.juju.com/publisher/spec/)                                              | Job search engine                                                          | `apiKey` | No    | Unknown |
+| [Open Skills](https://github.com/workforce-data-initiative/skills-api/wiki/API-Overview) | Job titles, skills and related jobs data                                   | No       | No    | Unknown |
+| [Reed](https://www.reed.co.uk/developers)                                                | Job board aggregator                                                       | `apiKey` | Yes   | Unknown |
+| [Search.gov Jobs](https://search.gov/developer/jobs.html)                                | Tap into a list of current jobs openings with the United States government | No       | Yes   | Unknown |
+| [The Muse](https://www.themuse.com/developers/api/v2)                                    | Job board and company profiles                                             | `apiKey` | Yes   | Unknown |
+| [Upwork](https://developers.upwork.com/)                                                 | Freelance job board and management system                                  | `OAuth`  | Yes   | Unknown |
+| [USAJOBS](https://developer.usajobs.gov/)                                                | US government job board                                                    | `apiKey` | Yes   | Unknown |
+| [ZipRecruiter](https://www.ziprecruiter.com/publishers)                                  | Job search app and website                                                 | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Machine Learning
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Clarifai](https://developer.clarifai.com/) | Computer Vision | `OAuth` | Yes | Unknown |
-| [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` | Yes | Yes |
-| [Deepcode](https://www.deepcode.ai/docs/Overview%252FOverview) | AI for code review | No | Yes | Unknown |
-| [Dialogflow](https://dialogflow.com) | Natural Language Processing | `apiKey` | Yes | Unknown |
-| [Keen IO](https://keen.io/) | Data Analytics | `apiKey` | Yes | Unknown |
-| [Time Door](https://timedoor.io) | A time series analysis API | `apiKey` | Yes | Yes |
-| [Unplugg](https://unplu.gg/test_api.html) | Forecasting API for timeseries data | `apiKey` | Yes | Unknown |
-| [Wit.ai](https://wit.ai/) | Natural Language Processing | `OAuth` | Yes | Unknown |
+
+| API                                                                               | Description                                             | Auth     | HTTPS | CORS    |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------- | -------- | ----- | ------- |
+| [Clarifai](https://developer.clarifai.com/)                                       | Computer Vision                                         | `OAuth`  | Yes   | Unknown |
+| [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` | Yes   | Yes     |
+| [Deepcode](https://www.deepcode.ai/docs/Overview%252FOverview)                    | AI for code review                                      | No       | Yes   | Unknown |
+| [Dialogflow](https://dialogflow.com)                                              | Natural Language Processing                             | `apiKey` | Yes   | Unknown |
+| [Keen IO](https://keen.io/)                                                       | Data Analytics                                          | `apiKey` | Yes   | Unknown |
+| [Time Door](https://timedoor.io)                                                  | A time series analysis API                              | `apiKey` | Yes   | Yes     |
+| [Unplugg](https://unplu.gg/test_api.html)                                         | Forecasting API for timeseries data                     | `apiKey` | Yes   | Unknown |
+| [Wit.ai](https://wit.ai/)                                                         | Natural Language Processing                             | `OAuth`  | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Music
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [AI Mastering](https://aimastering.com/api_docs/) | Automated Music Mastering | `apiKey` | Yes | Yes |
-| [Bandsintown](https://app.swaggerhub.com/apis/Bandsintown/PublicAPI/3.0.0) | Music Events | No | Yes | Unknown |
-| [Deezer](https://developers.deezer.com/api) | Music | `OAuth` | Yes | Unknown |
-| [Discogs](https://www.discogs.com/developers/) | Music | `OAuth` | Yes | Unknown |
-| [Genius](https://docs.genius.com/) | Crowdsourced lyrics and music knowledge | `OAuth` | Yes | Unknown |
-| [Genrenator](https://binaryjazz.us/genrenator-api/) | Music genre generator | No | Yes | Unknown |
-| [iTunes Search](https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/) | Software products | No | Yes | Unknown |
-| [Jamendo](https://developer.jamendo.com/v3.0/docs) | Music | `OAuth` | Yes | Unknown |
-| [KKBOX](https://developer.kkbox.com) | Get music libraries, playlists, charts, and perform out of KKBOX's platform | `OAuth` | Yes | Unknown |
-| [LastFm](https://www.last.fm/api) | Music | `apiKey` | Yes | Unknown |
-| [Lyrics.ovh](http://docs.lyricsovh.apiary.io/) | Simple API to retrieve the lyrics of a song | No | Yes | Unknown |
-| [Mixcloud](https://www.mixcloud.com/developers/) | Music | `OAuth` | Yes | Yes |
-| [MusicBrainz](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2) | Music | No | Yes | Unknown |
-| [Musikki](https://music-api.musikki.com/reference) | Music | `apiKey` | Yes | Unknown |
-| [Musixmatch](https://developer.musixmatch.com/) | Music | `apiKey` | Yes | Unknown |
-| [Openwhyd](https://openwhyd.github.io/openwhyd/API) | Download curated playlists of streaming tracks (YouTube, SoundCloud, etc...) | `No` | Yes | No |
-| [SearchLy](https://searchly.asuarez.dev/docs/v1) | Similarities search based on song lyrics | No | Yes | Unknown |
-| [Songkick](https://www.songkick.com/developer/) | Music Events | `OAuth` | Yes | Unknown |
-| [Songsterr](https://www.songsterr.com/a/wa/api/) | Provides guitar, bass and drums tabs and chords | No | Yes | Unknown |
-| [SoundCloud](https://developers.soundcloud.com/) | Allow users to upload and share sounds | `OAuth` | Yes | Unknown |
-| [Spotify](https://beta.developer.spotify.com/documentation/web-api/) | View Spotify music catalog, manage users' libraries, get recommendations and more | `OAuth` | Yes | Unknown |
-| [TasteDive](https://tastedive.com/read/api) | Similar artist API (also works for movies and TV shows) | `apiKey` | Yes | Unknown |
-| [TheAudioDB](https://www.theaudiodb.com/api_guide.php) | Music | `apiKey` | Yes | Unknown |
-| [Vagalume](https://api.vagalume.com.br/docs/) | Crowdsourced lyrics and music knowledge | `apiKey` | Yes | Unknown |
+
+| API                                                                                                              | Description                                                                       | Auth     | HTTPS | CORS    |
+| ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [AI Mastering](https://aimastering.com/api_docs/)                                                                | Automated Music Mastering                                                         | `apiKey` | Yes   | Yes     |
+| [Bandsintown](https://app.swaggerhub.com/apis/Bandsintown/PublicAPI/3.0.0)                                       | Music Events                                                                      | No       | Yes   | Unknown |
+| [Deezer](https://developers.deezer.com/api)                                                                      | Music                                                                             | `OAuth`  | Yes   | Unknown |
+| [Discogs](https://www.discogs.com/developers/)                                                                   | Music                                                                             | `OAuth`  | Yes   | Unknown |
+| [Genius](https://docs.genius.com/)                                                                               | Crowdsourced lyrics and music knowledge                                           | `OAuth`  | Yes   | Unknown |
+| [Genrenator](https://binaryjazz.us/genrenator-api/)                                                              | Music genre generator                                                             | No       | Yes   | Unknown |
+| [iTunes Search](https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/) | Software products                                                                 | No       | Yes   | Unknown |
+| [Jamendo](https://developer.jamendo.com/v3.0/docs)                                                               | Music                                                                             | `OAuth`  | Yes   | Unknown |
+| [KKBOX](https://developer.kkbox.com)                                                                             | Get music libraries, playlists, charts, and perform out of KKBOX's platform       | `OAuth`  | Yes   | Unknown |
+| [LastFm](https://www.last.fm/api)                                                                                | Music                                                                             | `apiKey` | Yes   | Unknown |
+| [Lyrics.ovh](http://docs.lyricsovh.apiary.io/)                                                                   | Simple API to retrieve the lyrics of a song                                       | No       | Yes   | Unknown |
+| [Mixcloud](https://www.mixcloud.com/developers/)                                                                 | Music                                                                             | `OAuth`  | Yes   | Yes     |
+| [MusicBrainz](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2)                                 | Music                                                                             | No       | Yes   | Unknown |
+| [Musikki](https://music-api.musikki.com/reference)                                                               | Music                                                                             | `apiKey` | Yes   | Unknown |
+| [Musixmatch](https://developer.musixmatch.com/)                                                                  | Music                                                                             | `apiKey` | Yes   | Unknown |
+| [Openwhyd](https://openwhyd.github.io/openwhyd/API)                                                              | Download curated playlists of streaming tracks (YouTube, SoundCloud, etc...)      | `No`     | Yes   | No      |
+| [SearchLy](https://searchly.asuarez.dev/docs/v1)                                                                 | Similarities search based on song lyrics                                          | No       | Yes   | Unknown |
+| [Songkick](https://www.songkick.com/developer/)                                                                  | Music Events                                                                      | `OAuth`  | Yes   | Unknown |
+| [Songsterr](https://www.songsterr.com/a/wa/api/)                                                                 | Provides guitar, bass and drums tabs and chords                                   | No       | Yes   | Unknown |
+| [SoundCloud](https://developers.soundcloud.com/)                                                                 | Allow users to upload and share sounds                                            | `OAuth`  | Yes   | Unknown |
+| [Spotify](https://beta.developer.spotify.com/documentation/web-api/)                                             | View Spotify music catalog, manage users' libraries, get recommendations and more | `OAuth`  | Yes   | Unknown |
+| [TasteDive](https://tastedive.com/read/api)                                                                      | Similar artist API (also works for movies and TV shows)                           | `apiKey` | Yes   | Unknown |
+| [TheAudioDB](https://www.theaudiodb.com/api_guide.php)                                                           | Music                                                                             | `apiKey` | Yes   | Unknown |
+| [Vagalume](https://api.vagalume.com.br/docs/)                                                                    | Crowdsourced lyrics and music knowledge                                           | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### News
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Associated Press](https://developer.ap.org/) | Search for news and metadata from Associated Press | `apiKey` | Yes | Unknown |
-| [Chronicling America](http://chroniclingamerica.loc.gov/about/api/) | Provides access to millions of pages of historic US newspapers from the Library of Congress | No | No | Unknown |
-| [Currents](https://currentsapi.services/) | Latest news published in various news sources, blogs and forums | `apiKey` | Yes | Yes |
-| [Feedbin](https://github.com/feedbin/feedbin-api) | RSS reader | `OAuth` | Yes | Unknown |
-| [Feedster](https://api.feedster.me/v1/docs/) | Searchable and categorized collections of RSS feeds | `apiKey` | Yes | Unknown |
-| [New York Times](https://developer.nytimes.com/) | Provides news | `apiKey` | Yes | Unknown |
-| [News](https://newsapi.org/) | Headlines currently published on a range of news sources and blogs | `apiKey` | Yes | Unknown |
-| [NPR One](http://dev.npr.org/api/) | Personalized news listening experience from NPR | `OAuth` | Yes | Unknown |
-| [The Guardian](http://open-platform.theguardian.com/) | Access all the content the Guardian creates, categorised by tags and section | `apiKey` | Yes | Unknown |
-| [The Old Reader](https://github.com/theoldreader/api) | RSS reader | `apiKey` | Yes | Unknown |
+
+| API                                                                 | Description                                                                                 | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Associated Press](https://developer.ap.org/)                       | Search for news and metadata from Associated Press                                          | `apiKey` | Yes   | Unknown |
+| [Chronicling America](http://chroniclingamerica.loc.gov/about/api/) | Provides access to millions of pages of historic US newspapers from the Library of Congress | No       | No    | Unknown |
+| [Currents](https://currentsapi.services/)                           | Latest news published in various news sources, blogs and forums                             | `apiKey` | Yes   | Yes     |
+| [Feedbin](https://github.com/feedbin/feedbin-api)                   | RSS reader                                                                                  | `OAuth`  | Yes   | Unknown |
+| [Feedster](https://api.feedster.me/v1/docs/)                        | Searchable and categorized collections of RSS feeds                                         | `apiKey` | Yes   | Unknown |
+| [New York Times](https://developer.nytimes.com/)                    | Provides news                                                                               | `apiKey` | Yes   | Unknown |
+| [News](https://newsapi.org/)                                        | Headlines currently published on a range of news sources and blogs                          | `apiKey` | Yes   | Unknown |
+| [NPR One](http://dev.npr.org/api/)                                  | Personalized news listening experience from NPR                                             | `OAuth`  | Yes   | Unknown |
+| [The Guardian](http://open-platform.theguardian.com/)               | Access all the content the Guardian creates, categorised by tags and section                | `apiKey` | Yes   | Unknown |
+| [The Old Reader](https://github.com/theoldreader/api)               | RSS reader                                                                                  | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Open Data
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [18F](http://18f.github.io/API-All-the-X/) | Unofficial US Federal Government API Development | No | No | Unknown |
-| [Abbreviation](https://market.mashape.com/daxeel/abbreviations) | Get abbreviations and meanings | `X-Mashape-Key` | Yes | Unknown |
-| [Archive.org](https://archive.readme.io/docs) | The Internet Archive | No | Yes | Unknown |
-| [ARSAT](https://datos.arsat.com.ar/developers/) | ARSAT public data | `apiKey` | Yes | Unknown |
-| [Callook.info](https://callook.info) | United States ham radio callsigns | No | Yes | Unknown |
-| [CARTO](https://carto.com/) | Location Information Prediction | `apiKey` | Yes | Unknown |
-| [Celebinfo](https://market.mashape.com/daxeel/celebinfo/) | Celebrity information | `X-Mashape-Key` | Yes | Unknown |
-| [CivicFeed](https://developers.civicfeed.com/) | News articles and public datasets | `apiKey` | Yes | Unknown |
-| [Datakick](https://www.datakick.org/api) | The open product database | `apiKey` | Yes | Unknown |
-| [Enigma Public](http://docs.enigma.com/public/public_v20_api_about) | Broadest collection of public data | `apiKey` | Yes | Yes |
-| [fonoApi](https://fonoapi.freshpixl.com/) | Mobile Device Description | No | Yes | Unknown |
-| [French Address Search](https://geo.api.gouv.fr/adresse) | Address search via the French Government | No | Yes | Unknown |
-| [LinkPreview](https://www.linkpreview.net) | Get JSON formatted summary with title, description and preview image for any requested URL | `apiKey` | Yes | Yes |
-| [Marijuana Strains](http://strains.evanbusse.com/) | Marijuana strains, races, flavors and effects | `apiKey` | No | Unknown |
-| [Microlink.io](https://microlink.io) | Extract structured data from any website | No | Yes | Yes |
-| [OpenCorporates](http://api.opencorporates.com/documentation/API-Reference) | Data on corporate entities and directors in many countries | `apiKey` | Yes | Unknown |
-| [Qmeta](https://api.qmeta.net/) | Global Search Engine | `apiKey` | Yes | Unknown |
-| [Quandl](https://www.quandl.com/) | Stock Market Data | No | Yes | Unknown |
-| [Recreation Information Database](https://ridb.recreation.gov/) | Recreational areas, federal lands, historic sites, museums, and other attractions/resources(US) | `apiKey` | Yes | Unknown |
-| [Scoop.it](http://www.scoop.it/dev) | Content Curation Service | `apiKey` | No | Unknown |
-| [Teleport](https://developers.teleport.org/) | Quality of Life Data | No | Yes | Unknown |
-| [Universities List](https://github.com/Hipo/university-domains-list) | University names, countries and domains | No | Yes | Unknown |
-| [University of Oslo](https://data.uio.no/) | Courses, lecture videos, detailed information for courses etc. for the University of Oslo (Norway) | No | Yes | Unknown |
-| [UPC database](https://upcdatabase.org/api) | More than 1.5 million barcode numbers from all around the world | `apiKey` | Yes | Unknown |
-| [Wikidata](https://www.wikidata.org/w/api.php?action=help) | Collaboratively edited knowledge base operated by the Wikimedia Foundation | `OAuth` | Yes | Unknown |
-| [Wikipedia](https://www.mediawiki.org/wiki/API:Main_page) | Mediawiki Encyclopedia | No | Yes | Unknown |
-| [Yelp](https://www.yelp.com/developers/documentation/v3) | Find Local Business | `OAuth` | Yes | Unknown |
+
+| API                                                                         | Description                                                                                        | Auth            | HTTPS | CORS    |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | --------------- | ----- | ------- |
+| [18F](http://18f.github.io/API-All-the-X/)                                  | Unofficial US Federal Government API Development                                                   | No              | No    | Unknown |
+| [Abbreviation](https://market.mashape.com/daxeel/abbreviations)             | Get abbreviations and meanings                                                                     | `X-Mashape-Key` | Yes   | Unknown |
+| [Archive.org](https://archive.readme.io/docs)                               | The Internet Archive                                                                               | No              | Yes   | Unknown |
+| [ARSAT](https://datos.arsat.com.ar/developers/)                             | ARSAT public data                                                                                  | `apiKey`        | Yes   | Unknown |
+| [Callook.info](https://callook.info)                                        | United States ham radio callsigns                                                                  | No              | Yes   | Unknown |
+| [CARTO](https://carto.com/)                                                 | Location Information Prediction                                                                    | `apiKey`        | Yes   | Unknown |
+| [Celebinfo](https://market.mashape.com/daxeel/celebinfo/)                   | Celebrity information                                                                              | `X-Mashape-Key` | Yes   | Unknown |
+| [CivicFeed](https://developers.civicfeed.com/)                              | News articles and public datasets                                                                  | `apiKey`        | Yes   | Unknown |
+| [Datakick](https://www.datakick.org/api)                                    | The open product database                                                                          | `apiKey`        | Yes   | Unknown |
+| [Enigma Public](http://docs.enigma.com/public/public_v20_api_about)         | Broadest collection of public data                                                                 | `apiKey`        | Yes   | Yes     |
+| [fonoApi](https://fonoapi.freshpixl.com/)                                   | Mobile Device Description                                                                          | No              | Yes   | Unknown |
+| [French Address Search](https://geo.api.gouv.fr/adresse)                    | Address search via the French Government                                                           | No              | Yes   | Unknown |
+| [LinkPreview](https://www.linkpreview.net)                                  | Get JSON formatted summary with title, description and preview image for any requested URL         | `apiKey`        | Yes   | Yes     |
+| [Marijuana Strains](http://strains.evanbusse.com/)                          | Marijuana strains, races, flavors and effects                                                      | `apiKey`        | No    | Unknown |
+| [Microlink.io](https://microlink.io)                                        | Extract structured data from any website                                                           | No              | Yes   | Yes     |
+| [OpenCorporates](http://api.opencorporates.com/documentation/API-Reference) | Data on corporate entities and directors in many countries                                         | `apiKey`        | Yes   | Unknown |
+| [Qmeta](https://api.qmeta.net/)                                             | Global Search Engine                                                                               | `apiKey`        | Yes   | Unknown |
+| [Quandl](https://www.quandl.com/)                                           | Stock Market Data                                                                                  | No              | Yes   | Unknown |
+| [Recreation Information Database](https://ridb.recreation.gov/)             | Recreational areas, federal lands, historic sites, museums, and other attractions/resources(US)    | `apiKey`        | Yes   | Unknown |
+| [Scoop.it](http://www.scoop.it/dev)                                         | Content Curation Service                                                                           | `apiKey`        | No    | Unknown |
+| [Teleport](https://developers.teleport.org/)                                | Quality of Life Data                                                                               | No              | Yes   | Unknown |
+| [Universities List](https://github.com/Hipo/university-domains-list)        | University names, countries and domains                                                            | No              | Yes   | Unknown |
+| [University of Oslo](https://data.uio.no/)                                  | Courses, lecture videos, detailed information for courses etc. for the University of Oslo (Norway) | No              | Yes   | Unknown |
+| [UPC database](https://upcdatabase.org/api)                                 | More than 1.5 million barcode numbers from all around the world                                    | `apiKey`        | Yes   | Unknown |
+| [Wikidata](https://www.wikidata.org/w/api.php?action=help)                  | Collaboratively edited knowledge base operated by the Wikimedia Foundation                         | `OAuth`         | Yes   | Unknown |
+| [Wikipedia](https://www.mediawiki.org/wiki/API:Main_page)                   | Mediawiki Encyclopedia                                                                             | No              | Yes   | Unknown |
+| [Yelp](https://www.yelp.com/developers/documentation/v3)                    | Find Local Business                                                                                | `OAuth`         | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Open Source Projects
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Countly](http://resources.count.ly/docs) | Countly web analytics | No | No | Unknown |
-| [Drupal.org](https://www.drupal.org/drupalorg/docs/api) | Drupal.org | No | Yes | Unknown |
-| [Evil Insult Generator](https://evilinsult.com/api) | Evil Insults | No | Yes | Yes |
-| [Libraries.io](https://libraries.io/api) | Open source software libraries | `apiKey` | Yes | Unknown |
+
+| API                                                     | Description                    | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------- | ------------------------------ | -------- | ----- | ------- |
+| [Countly](http://resources.count.ly/docs)               | Countly web analytics          | No       | No    | Unknown |
+| [Drupal.org](https://www.drupal.org/drupalorg/docs/api) | Drupal.org                     | No       | Yes   | Unknown |
+| [Evil Insult Generator](https://evilinsult.com/api)     | Evil Insults                   | No       | Yes   | Yes     |
+| [Libraries.io](https://libraries.io/api)                | Open source software libraries | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Patent
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [EPO](https://developers.epo.org/) | European patent search system api | `OAuth` | Yes | Unknown |
-| [TIPO](https://tiponet.tipo.gov.tw/Gazette/OpenData/OD/OD05.aspx?QryDS=API00) | Taiwan patent search system api | `apiKey` | Yes | Unknown |
-| [USPTO](https://www.uspto.gov/learning-and-resources/open-data-and-mobility) | USA patent api services | No | Yes | Unknown |
+
+| API                                                                           | Description                       | Auth     | HTTPS | CORS    |
+| ----------------------------------------------------------------------------- | --------------------------------- | -------- | ----- | ------- |
+| [EPO](https://developers.epo.org/)                                            | European patent search system api | `OAuth`  | Yes   | Unknown |
+| [TIPO](https://tiponet.tipo.gov.tw/Gazette/OpenData/OD/OD05.aspx?QryDS=API00) | Taiwan patent search system api   | `apiKey` | Yes   | Unknown |
+| [USPTO](https://www.uspto.gov/learning-and-resources/open-data-and-mobility)  | USA patent api services           | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Personality
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Advice Slip](http://api.adviceslip.com/) | Generate random advice slips | No | Yes | Unknown |
-| [chucknorris.io](https://api.chucknorris.io) | JSON API for hand curated Chuck Norris jokes | No | Yes | Unknown |
-| [FavQs.com](https://favqs.com/api) | FavQs allows you to collect, discover and share your favorite quotes | `apiKey` | Yes | Unknown |
-| [FOAAS](http://www.foaas.com/) | Fuck Off As A Service | No | No | Unknown |
-| [Forismatic](http://forismatic.com/en/api/) | Inspirational Quotes | No | No | Unknown |
-| [Hindi Quotes](https://hindi-quotes.vercel.app/) | Get random Hindi quotes of different categories.| No | Yes | Yes |
-| [icanhazdadjoke](https://icanhazdadjoke.com/api) | The largest selection of dad jokes on the internet | No | Yes | Unknown |
-| [kanye.rest](https://kanye.rest) | REST API for random Kanye West quotes | No | Yes | Yes |
-| [Medium](https://github.com/Medium/medium-api-docs) | Community of readers and writers offering unique perspectives on ideas | `OAuth` | Yes | Unknown |
-| [NaMoMemes](https://github.com/theIYD/NaMoMemes) | Memes on Narendra Modi | No | Yes | Unknown |
-| [Programming Quotes](https://github.com/skolakoda/programming-quotes-api) | Programming Quotes API for open source projects | No | Yes | Unknown |
-| [Quote Garden](https://pprathameshmore.github.io/QuoteGarden/) | REST API for more than 5000 famous quotes | No | Yes | Unknown |
-| [Quotes on Design](https://quotesondesign.com/api/) | Inspirational Quotes | No | Yes | Unknown |
-| [Traitify](https://app.traitify.com/developer) | Assess, collect and analyze Personality | No | Yes | Unknown |
-| [tronalddump.io](https://www.tronalddump.io) | Api & web archive for the things Donald Trump has said | No | Yes | Unknown |
+
+| API                                                                       | Description                                                            | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Advice Slip](http://api.adviceslip.com/)                                 | Generate random advice slips                                           | No       | Yes   | Unknown |
+| [chucknorris.io](https://api.chucknorris.io)                              | JSON API for hand curated Chuck Norris jokes                           | No       | Yes   | Unknown |
+| [FavQs.com](https://favqs.com/api)                                        | FavQs allows you to collect, discover and share your favorite quotes   | `apiKey` | Yes   | Unknown |
+| [FOAAS](http://www.foaas.com/)                                            | Fuck Off As A Service                                                  | No       | No    | Unknown |
+| [Forismatic](http://forismatic.com/en/api/)                               | Inspirational Quotes                                                   | No       | No    | Unknown |
+| [Hindi Quotes](https://hindi-quotes.vercel.app/)                          | Get random Hindi quotes of different categories.                       | No       | Yes   | Yes     |
+| [icanhazdadjoke](https://icanhazdadjoke.com/api)                          | The largest selection of dad jokes on the internet                     | No       | Yes   | Unknown |
+| [kanye.rest](https://kanye.rest)                                          | REST API for random Kanye West quotes                                  | No       | Yes   | Yes     |
+| [Medium](https://github.com/Medium/medium-api-docs)                       | Community of readers and writers offering unique perspectives on ideas | `OAuth`  | Yes   | Unknown |
+| [NaMoMemes](https://github.com/theIYD/NaMoMemes)                          | Memes on Narendra Modi                                                 | No       | Yes   | Unknown |
+| [Programming Quotes](https://github.com/skolakoda/programming-quotes-api) | Programming Quotes API for open source projects                        | No       | Yes   | Unknown |
+| [Quote Garden](https://pprathameshmore.github.io/QuoteGarden/)            | REST API for more than 5000 famous quotes                              | No       | Yes   | Unknown |
+| [Quotes on Design](https://quotesondesign.com/api/)                       | Inspirational Quotes                                                   | No       | Yes   | Unknown |
+| [Traitify](https://app.traitify.com/developer)                            | Assess, collect and analyze Personality                                | No       | Yes   | Unknown |
+| [tronalddump.io](https://www.tronalddump.io)                              | Api & web archive for the things Donald Trump has said                 | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Photography
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Flickr](https://www.flickr.com/services/api/) | Flickr Services | `OAuth` | Yes | Unknown |
-| [Getty Images](http://developers.gettyimages.com/en/) | Build applications using the world's most powerful imagery | `OAuth` | Yes | Unknown |
-| [Gfycat](https://developers.gfycat.com/api/) | Jiffier GIFs | `OAuth` | Yes | Unknown |
-| [Giphy](https://developers.giphy.com/docs/) | Get all your gifs | `apiKey` | Yes | Unknown |
-| [Gyazo](https://gyazo.com/api/docs) | Upload images | `apiKey` | Yes | Unknown |
-| [Imgur](https://apidocs.imgur.com/) | Images | `OAuth` | Yes | Unknown |
-| [Lorem Picsum](https://picsum.photos/) | Images from Unsplash | No | Yes | Unknown |
-| [Pexels](https://www.pexels.com/api/) | Free Stock Photos and Videos | `apiKey` | Yes | Yes |
-| [Pixabay](https://pixabay.com/sk/service/about/api/) | Photography | `apiKey` | Yes | Unknown |
-| [Pixhost](https://pixhost.org/api/index.html) | Upload images, photos, galleries | No | Yes | Unknown |
-| [PlaceKitten](https://placekitten.com/) | Resizable kitten placeholder images | No | Yes | Unknown |
-| [ScreenShotLayer](https://screenshotlayer.com) | URL 2 Image | No | Yes | Unknown |
-| [Unsplash](https://unsplash.com/developers) | Photography | `OAuth` | Yes | Unknown |
-| [Wallhaven](https://wallhaven.cc/help/api) | Wallpapers | `apiKey` | Yes | Unknown |
+
+| API                                                   | Description                                                | Auth     | HTTPS | CORS    |
+| ----------------------------------------------------- | ---------------------------------------------------------- | -------- | ----- | ------- |
+| [Flickr](https://www.flickr.com/services/api/)        | Flickr Services                                            | `OAuth`  | Yes   | Unknown |
+| [Getty Images](http://developers.gettyimages.com/en/) | Build applications using the world's most powerful imagery | `OAuth`  | Yes   | Unknown |
+| [Gfycat](https://developers.gfycat.com/api/)          | Jiffier GIFs                                               | `OAuth`  | Yes   | Unknown |
+| [Giphy](https://developers.giphy.com/docs/)           | Get all your gifs                                          | `apiKey` | Yes   | Unknown |
+| [Gyazo](https://gyazo.com/api/docs)                   | Upload images                                              | `apiKey` | Yes   | Unknown |
+| [Imgur](https://apidocs.imgur.com/)                   | Images                                                     | `OAuth`  | Yes   | Unknown |
+| [Lorem Picsum](https://picsum.photos/)                | Images from Unsplash                                       | No       | Yes   | Unknown |
+| [Pexels](https://www.pexels.com/api/)                 | Free Stock Photos and Videos                               | `apiKey` | Yes   | Yes     |
+| [Pixabay](https://pixabay.com/sk/service/about/api/)  | Photography                                                | `apiKey` | Yes   | Unknown |
+| [Pixhost](https://pixhost.org/api/index.html)         | Upload images, photos, galleries                           | No       | Yes   | Unknown |
+| [PlaceKitten](https://placekitten.com/)               | Resizable kitten placeholder images                        | No       | Yes   | Unknown |
+| [ScreenShotLayer](https://screenshotlayer.com)        | URL 2 Image                                                | No       | Yes   | Unknown |
+| [Unsplash](https://unsplash.com/developers)           | Photography                                                | `OAuth`  | Yes   | Unknown |
+| [Wallhaven](https://wallhaven.cc/help/api)            | Wallpapers                                                 | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Science & Math
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [arcsecond.io](https://api.arcsecond.io/) | Multiple astronomy data sources | No | Yes | Unknown |
-| [CORE](https://core.ac.uk/services#api) | Access the world's Open Access research papers | `apiKey` | Yes | Unknown |
-| [GBIF](http://api.gbif.org/v1/) | Global Biodiversity Information Facility | No | Yes | Yes |
-| [iDigBio](https://github.com/idigbio/idigbio-search-api/wiki) | Access millions of museum specimens from organizations around the world | No | Yes | Unknown |
-| [inspirehep.net](https://inspirehep.net/info/hep/api?ln=en) | High Energy Physics info. system | No | Yes | Unknown |
-| [ITIS](https://www.itis.gov/ws_description.html) | Integrated Taxonomic Information System | No | Yes | Unknown |
-| [Launch Library](https://launchlibrary.net/docs/1.3/api.html) | Upcoming Space Launches | No | Yes | Unknown |
-| [Minor Planet Center](http://www.asterank.com/mpc) | Asterank.com Information | No | No | Unknown |
-| [NASA](https://api.nasa.gov) | NASA data, including imagery | No | Yes | Unknown |
-| [NASA APOD (unofficial API)](https://apodapi.herokuapp.com/) | API for getting APOD (Astronomy Image of the Day) images along with metadata | No | Yes | Yes |
-| [Newton](https://newton.now.sh/) | Symbolic and Arithmetic Math Calculator | No | Yes | Unknown |
-| [Numbers](http://numbersapi.com) | Facts about numbers | No | No | Unknown |
-| [Open Notify](http://open-notify.org/Open-Notify-API/) | ISS astronauts, current location, etc | No | No | Unknown |
-| [Open Science Framework](https://developer.osf.io) | Repository and archive for study designs, research materials, data, manuscripts, etc | No | Yes | Unknown |
-| [SHARE](https://share.osf.io/api/v2/) | A free, open, dataset about research and scholarly activities | No | Yes | Unknown |
-| [SpaceX](https://github.com/r-spacex/SpaceX-API) | Company, vehicle, launchpad and launch data | No | Yes | Unknown |
-| [Sunrise and Sunset](https://sunrise-sunset.org/api) | Sunset and sunrise times for a given latitude and longitude | No | Yes | Unknown |
-| [Trefle](https://trefle.io/) | Botanical data for plant species | `apiKey` | Yes | Unknown |
-| [USGS Earthquake Hazards Program](https://earthquake.usgs.gov/fdsnws/event/1/) | Earthquakes data real-time | No | Yes | Unknown |
-| [USGS Water Services](https://waterservices.usgs.gov/) | Water quality and level info for rivers and lakes | No | Yes | Unknown |
-| [World Bank](https://datahelpdesk.worldbank.org/knowledgebase/topics/125589) | World Data | No | No | Unknown |
+
+| API                                                                            | Description                                                                          | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ | -------- | ----- | ------- |
+| [arcsecond.io](https://api.arcsecond.io/)                                      | Multiple astronomy data sources                                                      | No       | Yes   | Unknown |
+| [CORE](https://core.ac.uk/services#api)                                        | Access the world's Open Access research papers                                       | `apiKey` | Yes   | Unknown |
+| [GBIF](http://api.gbif.org/v1/)                                                | Global Biodiversity Information Facility                                             | No       | Yes   | Yes     |
+| [iDigBio](https://github.com/idigbio/idigbio-search-api/wiki)                  | Access millions of museum specimens from organizations around the world              | No       | Yes   | Unknown |
+| [inspirehep.net](https://inspirehep.net/info/hep/api?ln=en)                    | High Energy Physics info. system                                                     | No       | Yes   | Unknown |
+| [ITIS](https://www.itis.gov/ws_description.html)                               | Integrated Taxonomic Information System                                              | No       | Yes   | Unknown |
+| [Launch Library](https://launchlibrary.net/docs/1.3/api.html)                  | Upcoming Space Launches                                                              | No       | Yes   | Unknown |
+| [Minor Planet Center](http://www.asterank.com/mpc)                             | Asterank.com Information                                                             | No       | No    | Unknown |
+| [NASA](https://api.nasa.gov)                                                   | NASA data, including imagery                                                         | No       | Yes   | Unknown |
+| [NASA APOD (unofficial API)](https://apodapi.herokuapp.com/)                   | API for getting APOD (Astronomy Image of the Day) images along with metadata         | No       | Yes   | Yes     |
+| [Newton](https://newton.now.sh/)                                               | Symbolic and Arithmetic Math Calculator                                              | No       | Yes   | Unknown |
+| [Numbers](http://numbersapi.com)                                               | Facts about numbers                                                                  | No       | No    | Unknown |
+| [Open Notify](http://open-notify.org/Open-Notify-API/)                         | ISS astronauts, current location, etc                                                | No       | No    | Unknown |
+| [Open Science Framework](https://developer.osf.io)                             | Repository and archive for study designs, research materials, data, manuscripts, etc | No       | Yes   | Unknown |
+| [SHARE](https://share.osf.io/api/v2/)                                          | A free, open, dataset about research and scholarly activities                        | No       | Yes   | Unknown |
+| [SpaceX](https://github.com/r-spacex/SpaceX-API)                               | Company, vehicle, launchpad and launch data                                          | No       | Yes   | Unknown |
+| [Sunrise and Sunset](https://sunrise-sunset.org/api)                           | Sunset and sunrise times for a given latitude and longitude                          | No       | Yes   | Unknown |
+| [Trefle](https://trefle.io/)                                                   | Botanical data for plant species                                                     | `apiKey` | Yes   | Unknown |
+| [USGS Earthquake Hazards Program](https://earthquake.usgs.gov/fdsnws/event/1/) | Earthquakes data real-time                                                           | No       | Yes   | Unknown |
+| [USGS Water Services](https://waterservices.usgs.gov/)                         | Water quality and level info for rivers and lakes                                    | No       | Yes   | Unknown |
+| [World Bank](https://datahelpdesk.worldbank.org/knowledgebase/topics/125589)   | World Data                                                                           | No       | No    | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Security
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Censys.io](https://censys.io/api) | Search engine for Internet connected host and devices | `apiKey` | Yes | No |
-| [CRXcavator](https://crxcavator.io/apidocs) | Chrome extension risk scoring | `apiKey` | Yes | Unknown |
-| [FilterLists](https://filterlists.com/api) | Lists of filters for adblockers and firewalls | No | Yes | Unknown |
-| [HaveIBeenPwned](https://haveibeenpwned.com/API/v3) | Passwords which have previously been exposed in data breaches | `apiKey` | Yes | Unknown |
-| [National Vulnerability Database](https://nvd.nist.gov/vuln/Data-Feeds/JSON-feed-changelog) | U.S. National Vulnerability Database | No | Yes | Unknown |
-| [SecurityTrails](https://securitytrails.com/corp/apidocs) | Domain and IP related information such as current and historical WHOIS and DNS records | `apiKey` | Yes | Unknown |
-| [Shodan](https://developer.shodan.io/) | Search engine for Internet connected devices | `apiKey` | Yes | Unknown |
-| [UK Police](https://data.police.uk/docs/) | UK Police data | No | Yes | Unknown |
+
+| API                                                                                         | Description                                                                            | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Censys.io](https://censys.io/api)                                                          | Search engine for Internet connected host and devices                                  | `apiKey` | Yes   | No      |
+| [CRXcavator](https://crxcavator.io/apidocs)                                                 | Chrome extension risk scoring                                                          | `apiKey` | Yes   | Unknown |
+| [FilterLists](https://filterlists.com/api)                                                  | Lists of filters for adblockers and firewalls                                          | No       | Yes   | Unknown |
+| [HaveIBeenPwned](https://haveibeenpwned.com/API/v3)                                         | Passwords which have previously been exposed in data breaches                          | `apiKey` | Yes   | Unknown |
+| [National Vulnerability Database](https://nvd.nist.gov/vuln/Data-Feeds/JSON-feed-changelog) | U.S. National Vulnerability Database                                                   | No       | Yes   | Unknown |
+| [SecurityTrails](https://securitytrails.com/corp/apidocs)                                   | Domain and IP related information such as current and historical WHOIS and DNS records | `apiKey` | Yes   | Unknown |
+| [Shodan](https://developer.shodan.io/)                                                      | Search engine for Internet connected devices                                           | `apiKey` | Yes   | Unknown |
+| [UK Police](https://data.police.uk/docs/)                                                   | UK Police data                                                                         | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Shopping
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Best Buy](https://bestbuyapis.github.io/api-documentation/#overview) | Products, Buying Options, Categories, Recommendations, Stores and Commerce | `apiKey` | Yes | Unknown |
-| [Bratabase](https://developers.bratabase.com/) | Database of different types of Bra Sizes | `OAuth` | Yes | Unknown |
-| [eBay](https://go.developer.ebay.com/) | Sell and Buy on eBay | `OAuth` | Yes | Unknown |
-| [Wal-Mart](https://developer.walmartlabs.com/docs) | Item price and availability | `apiKey` | Yes | Unknown |
-| [Wegmans](https://dev.wegmans.io) | Wegmans Food Markets | `apiKey` | Yes | Unknown |
+
+| API                                                                   | Description                                                                | Auth     | HTTPS | CORS    |
+| --------------------------------------------------------------------- | -------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Best Buy](https://bestbuyapis.github.io/api-documentation/#overview) | Products, Buying Options, Categories, Recommendations, Stores and Commerce | `apiKey` | Yes   | Unknown |
+| [Bratabase](https://developers.bratabase.com/)                        | Database of different types of Bra Sizes                                   | `OAuth`  | Yes   | Unknown |
+| [eBay](https://go.developer.ebay.com/)                                | Sell and Buy on eBay                                                       | `OAuth`  | Yes   | Unknown |
+| [Wal-Mart](https://developer.walmartlabs.com/docs)                    | Item price and availability                                                | `apiKey` | Yes   | Unknown |
+| [Wegmans](https://dev.wegmans.io)                                     | Wegmans Food Markets                                                       | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Social
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Buffer](https://buffer.com/developers/api) | Access to pending and sent updates in Buffer | `OAuth` | Yes | Unknown |
-| [Cisco Spark](https://developer.ciscospark.com) | Team Collaboration Software | `OAuth` | Yes | Unknown |
-| [Discord](https://discordapp.com/developers/docs/intro) | Make bots for Discord, integrate Discord onto an external platform | `OAuth` | Yes | Unknown |
-| [Disqus](https://disqus.com/api/docs/auth/) | Communicate with Disqus data | `OAuth` | Yes | Unknown |
-| [Facebook](https://developers.facebook.com/) | Facebook Login, Share on FB, Social Plugins, Analytics and more | `OAuth` | Yes | Unknown |
-| [Foursquare](https://developer.foursquare.com/) | Interact with Foursquare users and places (geolocation-based checkins, photos, tips, events, etc) | `OAuth` | Yes | Unknown |
-| [Fuck Off as a Service](https://www.foaas.com) | Asks someone to fuck off | No | Yes | Unknown |
-| [Full Contact](https://www.fullcontact.com/developer/docs/) | Get Social Media profiles and contact Information | `OAuth` | Yes | Unknown |
-| [HackerNews](https://github.com/HackerNews/API) | Social news for CS and entrepreneurship | No | Yes | Unknown |
-| [Instagram](https://www.instagram.com/developer/) | Instagram Login, Share on Instagram, Social Plugins and more | `OAuth` | Yes | Unknown |
-| [LinkedIn](https://developer.linkedin.com/docs/rest-api) | The foundation of all digital integrations with LinkedIn | `OAuth` | Yes | Unknown |
-| [Meetup.com](https://www.meetup.com/meetup_api/) | Data about Meetups from Meetup.com | `apiKey` | Yes | Unknown |
-| [Mixer](https://dev.mixer.com/) | Game Streaming API | `OAuth` | Yes | Unknown |
-| [MySocialApp](https://mysocialapp.io) | Seamless Social Networking features, API, SDK to any app | `apiKey` | Yes | Unknown |
-| [Open Collective](https://docs.opencollective.com/help/developers/api) | Get Open Collective data | No | Yes | Unknown |
-| [Pinterest](https://developers.pinterest.com/) | The world's catalog of ideas | `OAuth` | Yes | Unknown |
-| [PWRTelegram bot](https://pwrtelegram.xyz) | Boosted version of the Telegram bot API | `apiKey` | Yes | Unknown |
-| [Reddit](https://www.reddit.com/dev/api) | Homepage of the internet | `OAuth` | Yes | Unknown |
-| [SharedCount](http://docs.sharedcount.com/) | Social media like and share data for any URL | `apiKey` | Yes | Unknown |
-| [Slack](https://api.slack.com/) | Team Instant Messaging | `OAuth` | Yes | Unknown |
-| [Telegram Bot](https://core.telegram.org/bots/api) | Simplified HTTP version of the MTProto API for bots | `apiKey` | Yes | Unknown |
-| [Telegram MTProto](https://core.telegram.org/api#getting-started) | Read and write Telegram data | `OAuth` | Yes | Unknown |
-| [Trash Nothing](https://trashnothing.com/developer) | A freecycling community with thousands of free items posted every day | `OAuth` | Yes | Yes |
-| [Tumblr](https://www.tumblr.com/docs/en/api/v2) | Read and write Tumblr Data | `OAuth` | Yes | Unknown |
-| [Twitch](https://dev.twitch.tv/docs) | Game Streaming API | `OAuth` | Yes | Unknown |
-| [Twitter](https://developer.twitter.com/en/docs) | Read and write Twitter data | `OAuth` | Yes | No |
-| [vk](https://vk.com/dev/sites) | Read and write vk data | `OAuth` | Yes | Unknown |
+
+| API                                                                    | Description                                                                                       | Auth     | HTTPS | CORS    |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Buffer](https://buffer.com/developers/api)                            | Access to pending and sent updates in Buffer                                                      | `OAuth`  | Yes   | Unknown |
+| [Cisco Spark](https://developer.ciscospark.com)                        | Team Collaboration Software                                                                       | `OAuth`  | Yes   | Unknown |
+| [Discord](https://discordapp.com/developers/docs/intro)                | Make bots for Discord, integrate Discord onto an external platform                                | `OAuth`  | Yes   | Unknown |
+| [Disqus](https://disqus.com/api/docs/auth/)                            | Communicate with Disqus data                                                                      | `OAuth`  | Yes   | Unknown |
+| [Facebook](https://developers.facebook.com/)                           | Facebook Login, Share on FB, Social Plugins, Analytics and more                                   | `OAuth`  | Yes   | Unknown |
+| [Foursquare](https://developer.foursquare.com/)                        | Interact with Foursquare users and places (geolocation-based checkins, photos, tips, events, etc) | `OAuth`  | Yes   | Unknown |
+| [Fuck Off as a Service](https://www.foaas.com)                         | Asks someone to fuck off                                                                          | No       | Yes   | Unknown |
+| [Full Contact](https://www.fullcontact.com/developer/docs/)            | Get Social Media profiles and contact Information                                                 | `OAuth`  | Yes   | Unknown |
+| [HackerNews](https://github.com/HackerNews/API)                        | Social news for CS and entrepreneurship                                                           | No       | Yes   | Unknown |
+| [Instagram](https://www.instagram.com/developer/)                      | Instagram Login, Share on Instagram, Social Plugins and more                                      | `OAuth`  | Yes   | Unknown |
+| [LinkedIn](https://developer.linkedin.com/docs/rest-api)               | The foundation of all digital integrations with LinkedIn                                          | `OAuth`  | Yes   | Unknown |
+| [Meetup.com](https://www.meetup.com/meetup_api/)                       | Data about Meetups from Meetup.com                                                                | `apiKey` | Yes   | Unknown |
+| [Mixer](https://dev.mixer.com/)                                        | Game Streaming API                                                                                | `OAuth`  | Yes   | Unknown |
+| [MySocialApp](https://mysocialapp.io)                                  | Seamless Social Networking features, API, SDK to any app                                          | `apiKey` | Yes   | Unknown |
+| [Open Collective](https://docs.opencollective.com/help/developers/api) | Get Open Collective data                                                                          | No       | Yes   | Unknown |
+| [Pinterest](https://developers.pinterest.com/)                         | The world's catalog of ideas                                                                      | `OAuth`  | Yes   | Unknown |
+| [PWRTelegram bot](https://pwrtelegram.xyz)                             | Boosted version of the Telegram bot API                                                           | `apiKey` | Yes   | Unknown |
+| [Reddit](https://www.reddit.com/dev/api)                               | Homepage of the internet                                                                          | `OAuth`  | Yes   | Unknown |
+| [SharedCount](http://docs.sharedcount.com/)                            | Social media like and share data for any URL                                                      | `apiKey` | Yes   | Unknown |
+| [Slack](https://api.slack.com/)                                        | Team Instant Messaging                                                                            | `OAuth`  | Yes   | Unknown |
+| [Telegram Bot](https://core.telegram.org/bots/api)                     | Simplified HTTP version of the MTProto API for bots                                               | `apiKey` | Yes   | Unknown |
+| [Telegram MTProto](https://core.telegram.org/api#getting-started)      | Read and write Telegram data                                                                      | `OAuth`  | Yes   | Unknown |
+| [Trash Nothing](https://trashnothing.com/developer)                    | A freecycling community with thousands of free items posted every day                             | `OAuth`  | Yes   | Yes     |
+| [Tumblr](https://www.tumblr.com/docs/en/api/v2)                        | Read and write Tumblr Data                                                                        | `OAuth`  | Yes   | Unknown |
+| [Twitch](https://dev.twitch.tv/docs)                                   | Game Streaming API                                                                                | `OAuth`  | Yes   | Unknown |
+| [Twitter](https://developer.twitter.com/en/docs)                       | Read and write Twitter data                                                                       | `OAuth`  | Yes   | No      |
+| [vk](https://vk.com/dev/sites)                                         | Read and write vk data                                                                            | `OAuth`  | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Sports & Fitness
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [balldontlie](https://balldontlie.io) | Ballldontlie provides access to stats data from the NBA | No | Yes | Yes |
-| [BikeWise](https://www.bikewise.org/documentation/api_v2) | Bikewise is a place to learn about and report bike crashes, hazards and thefts | No | Yes | Unknown |
-| [Canadian Football League (CFL)](http://api.cfl.ca/) | Official JSON API providing real-time league, team and player statistics about the CFL | `apiKey` | Yes | No |
-| [Cartola FC](https://github.com/wgenial/cartrolandofc) | The Cartola FC API serves to check the partial points of your team | No | Yes | Unknown |
-| [City Bikes](http://api.citybik.es/v2/) | City Bikes around the world | No | No | Unknown |
-| [Cricket Live Scores](https://market.mashape.com/dev132/cricket-live-scores) | Live cricket scores | `X-Mashape-Key` | Yes | Unknown |
-| [Ergast F1](http://ergast.com/mrd/) | F1 data from the beginning of the world championships in 1950 | No | Yes | Unknown |
-| [Fitbit](https://dev.fitbit.com/) | Fitbit Information | `OAuth` | Yes | Unknown |
-| [Football (Soccer) Videos](https://www.scorebat.com/video-api/) | Embed codes for goals and highlights from Premier League, Bundesliga, Serie A and many more | No | Yes | Yes |
-| [Football Prediction](https://boggio-analytics.com/fp-api/) | Predictions for upcoming football matches, odds, results and stats | `X-Mashape-Key` | Yes | Unknown |
-| [Football-Data.org](http://api.football-data.org/index) | Football Data | No | No | Unknown |
-| [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux's self-service bicycles | `apiKey` | Yes | Unknown |
-| [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description) | Current and historical NBA Statistics | No | Yes | Unknown |
-| [NFL Arrests](http://nflarrest.com/api/) | NFL Arrest Data | No | No | Unknown |
-| [NHL Records and Stats](https://gitlab.com/dword4/nhlapi) | NHL historical data and statistics | No | Yes | Unknown |
-| [Pro Motocross](http://promotocrossapi.com) | The RESTful AMA Pro Motocross lap times for every racer on the start gate | No | No | Unknown |
-| [Strava](https://strava.github.io/api/) | Connect with athletes, activities and more | `OAuth` | Yes | Unknown |
-| [SuredBits](https://suredbits.com/api/) | Query sports data, including teams, players, games, scores and statistics | No | No | No |
-| [TheSportsDB](https://www.thesportsdb.com/api.php) | Crowd-Sourced Sports Data and Artwork | `apiKey` | Yes | Yes |
-| [Wger](https://wger.de/en/software/api) | Workout manager data as exercises, muscles or equipment | `apiKey` | Yes | Unknown |
+
+| API                                                                          | Description                                                                                 | Auth            | HTTPS | CORS    |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | --------------- | ----- | ------- |
+| [balldontlie](https://balldontlie.io)                                        | Ballldontlie provides access to stats data from the NBA                                     | No              | Yes   | Yes     |
+| [BikeWise](https://www.bikewise.org/documentation/api_v2)                    | Bikewise is a place to learn about and report bike crashes, hazards and thefts              | No              | Yes   | Unknown |
+| [Canadian Football League (CFL)](http://api.cfl.ca/)                         | Official JSON API providing real-time league, team and player statistics about the CFL      | `apiKey`        | Yes   | No      |
+| [Cartola FC](https://github.com/wgenial/cartrolandofc)                       | The Cartola FC API serves to check the partial points of your team                          | No              | Yes   | Unknown |
+| [City Bikes](http://api.citybik.es/v2/)                                      | City Bikes around the world                                                                 | No              | No    | Unknown |
+| [Cricket Live Scores](https://market.mashape.com/dev132/cricket-live-scores) | Live cricket scores                                                                         | `X-Mashape-Key` | Yes   | Unknown |
+| [Ergast F1](http://ergast.com/mrd/)                                          | F1 data from the beginning of the world championships in 1950                               | No              | Yes   | Unknown |
+| [Fitbit](https://dev.fitbit.com/)                                            | Fitbit Information                                                                          | `OAuth`         | Yes   | Unknown |
+| [Football (Soccer) Videos](https://www.scorebat.com/video-api/)              | Embed codes for goals and highlights from Premier League, Bundesliga, Serie A and many more | No              | Yes   | Yes     |
+| [Football Prediction](https://boggio-analytics.com/fp-api/)                  | Predictions for upcoming football matches, odds, results and stats                          | `X-Mashape-Key` | Yes   | Unknown |
+| [Football-Data.org](http://api.football-data.org/index)                      | Football Data                                                                               | No              | No    | Unknown |
+| [JCDecaux Bike](https://developer.jcdecaux.com/)                             | JCDecaux's self-service bicycles                                                            | `apiKey`        | Yes   | Unknown |
+| [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description)        | Current and historical NBA Statistics                                                       | No              | Yes   | Unknown |
+| [NFL Arrests](http://nflarrest.com/api/)                                     | NFL Arrest Data                                                                             | No              | No    | Unknown |
+| [NHL Records and Stats](https://gitlab.com/dword4/nhlapi)                    | NHL historical data and statistics                                                          | No              | Yes   | Unknown |
+| [Pro Motocross](http://promotocrossapi.com)                                  | The RESTful AMA Pro Motocross lap times for every racer on the start gate                   | No              | No    | Unknown |
+| [Strava](https://strava.github.io/api/)                                      | Connect with athletes, activities and more                                                  | `OAuth`         | Yes   | Unknown |
+| [SuredBits](https://suredbits.com/api/)                                      | Query sports data, including teams, players, games, scores and statistics                   | No              | No    | No      |
+| [TheSportsDB](https://www.thesportsdb.com/api.php)                           | Crowd-Sourced Sports Data and Artwork                                                       | `apiKey`        | Yes   | Yes     |
+| [Wger](https://wger.de/en/software/api)                                      | Workout manager data as exercises, muscles or equipment                                     | `apiKey`        | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Test Data
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Adorable Avatars](http://avatars.adorable.io) | Generate random cartoon avatars | No | Yes | Unknown |
-| [Bacon Ipsum](https://baconipsum.com/json-api/) | A Meatier Lorem Ipsum Generator | No | Yes | Unknown |
-| [Dicebear Avatars](https://avatars.dicebear.com/) | Generate random pixel-art avatars | No | Yes | No |
-| [FakeJSON](https://fakejson.com) | Service to generate test and fake data | `apiKey` | Yes | Yes |
-| [FHIR](http://fhirtest.uhn.ca/home) | Fast Healthcare Interoperability Resources test data | No | Yes | Unknown |
-| [Hipster Ipsum](http://hipsterjesus.com/) | Generates Hipster Ipsum text | No | No | Unknown |
-| [Identicon](https://www.kwelo.com/media/identicon/) | Generates abstract avatar image | No | Yes | Yes |
-| [JSONPlaceholder](http://jsonplaceholder.typicode.com/) | Fake data for testing and prototyping | No | No | Unknown |
-| [Lorem Text](https://market.mashape.com/montanaflynn/lorem-text-generator) | Generates Lorem Ipsum text | `X-Mashape-Key` | Yes | Unknown |
-| [LoremPicsum](http://lorempicsum.com) | Generate placeholder pictures | No | No | Unknown |
-| [Loripsum](http://loripsum.net/) | The "lorem ipsum" generator that doesn't suck | No | No | Unknown |
-| [RandomUser](https://randomuser.me) | Generates random user data | No | Yes | Unknown |
-| [RoboHash](https://robohash.org/) | Generate random robot/alien avatars | No | Yes | Unknown |
-| [This Person Does not Exist](https://thispersondoesnotexist.com) | Generates real-life faces of people who do not exist | No | Yes | Unknown |
-| [UI Names](https://github.com/thm/uinames) | Generate random fake names | No | Yes | Unknown |
-| [Yes No](https://yesno.wtf/api) | Generate yes or no randomly | No | Yes | Unknown |
+
+| API                                                                        | Description                                          | Auth            | HTTPS | CORS    |
+| -------------------------------------------------------------------------- | ---------------------------------------------------- | --------------- | ----- | ------- |
+| [Adorable Avatars](http://avatars.adorable.io)                             | Generate random cartoon avatars                      | No              | Yes   | Unknown |
+| [Bacon Ipsum](https://baconipsum.com/json-api/)                            | A Meatier Lorem Ipsum Generator                      | No              | Yes   | Unknown |
+| [Dicebear Avatars](https://avatars.dicebear.com/)                          | Generate random pixel-art avatars                    | No              | Yes   | No      |
+| [FakeJSON](https://fakejson.com)                                           | Service to generate test and fake data               | `apiKey`        | Yes   | Yes     |
+| [FHIR](http://fhirtest.uhn.ca/home)                                        | Fast Healthcare Interoperability Resources test data | No              | Yes   | Unknown |
+| [Hipster Ipsum](http://hipsterjesus.com/)                                  | Generates Hipster Ipsum text                         | No              | No    | Unknown |
+| [Identicon](https://www.kwelo.com/media/identicon/)                        | Generates abstract avatar image                      | No              | Yes   | Yes     |
+| [JSONPlaceholder](http://jsonplaceholder.typicode.com/)                    | Fake data for testing and prototyping                | No              | No    | Unknown |
+| [Lorem Text](https://market.mashape.com/montanaflynn/lorem-text-generator) | Generates Lorem Ipsum text                           | `X-Mashape-Key` | Yes   | Unknown |
+| [LoremPicsum](http://lorempicsum.com)                                      | Generate placeholder pictures                        | No              | No    | Unknown |
+| [Loripsum](http://loripsum.net/)                                           | The "lorem ipsum" generator that doesn't suck        | No              | No    | Unknown |
+| [RandomUser](https://randomuser.me)                                        | Generates random user data                           | No              | Yes   | Unknown |
+| [RoboHash](https://robohash.org/)                                          | Generate random robot/alien avatars                  | No              | Yes   | Unknown |
+| [This Person Does not Exist](https://thispersondoesnotexist.com)           | Generates real-life faces of people who do not exist | No              | Yes   | Unknown |
+| [UI Names](https://github.com/thm/uinames)                                 | Generate random fake names                           | No              | Yes   | Unknown |
+| [Yes No](https://yesno.wtf/api)                                            | Generate yes or no randomly                          | No              | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Text Analysis
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Aylien Text Analysis](http://docs.aylien.com/) | A collection of information retrieval and natural language APIs | `apiKey` | Yes | Unknown |
-| [Cloudmersive Natural Language Processing](https://www.cloudmersive.com/nlp-api) | Natural language processing and text analysis | `apiKey` | Yes | Yes |
-| [Detect Language](https://detectlanguage.com/) | Detects text language | `apiKey` | Yes | Unknown |
-| [Google Cloud Natural](https://cloud.google.com/natural-language/docs/) | Natural language understanding technology, including sentiment, entity and syntax analysis | `apiKey` | Yes | Unknown |
-| [Language Identification](https://rapidapi.com/BigLobster/api/language-identification-prediction) | Automatic language detection for any texts, supports over 175 languages | `X-Mashape-Key` | Yes | Unknown |
-| [Semantira](https://semantria.readme.io/docs) | Text Analytics with sentiment analysis, categorization & named entity extraction | `OAuth` | Yes | Unknown |
-| [Watson Natural Language Understanding](https://www.ibm.com/watson/developercloud/natural-language-understanding/api/v1/) | Natural language processing for advanced text analysis | `OAuth` | Yes | Unknown |
+
+| API                                                                                                                       | Description                                                                                | Auth            | HTTPS | CORS    |
+| ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | --------------- | ----- | ------- |
+| [Aylien Text Analysis](http://docs.aylien.com/)                                                                           | A collection of information retrieval and natural language APIs                            | `apiKey`        | Yes   | Unknown |
+| [Cloudmersive Natural Language Processing](https://www.cloudmersive.com/nlp-api)                                          | Natural language processing and text analysis                                              | `apiKey`        | Yes   | Yes     |
+| [Detect Language](https://detectlanguage.com/)                                                                            | Detects text language                                                                      | `apiKey`        | Yes   | Unknown |
+| [Google Cloud Natural](https://cloud.google.com/natural-language/docs/)                                                   | Natural language understanding technology, including sentiment, entity and syntax analysis | `apiKey`        | Yes   | Unknown |
+| [Language Identification](https://rapidapi.com/BigLobster/api/language-identification-prediction)                         | Automatic language detection for any texts, supports over 175 languages                    | `X-Mashape-Key` | Yes   | Unknown |
+| [Semantira](https://semantria.readme.io/docs)                                                                             | Text Analytics with sentiment analysis, categorization & named entity extraction           | `OAuth`         | Yes   | Unknown |
+| [Watson Natural Language Understanding](https://www.ibm.com/watson/developercloud/natural-language-understanding/api/v1/) | Natural language processing for advanced text analysis                                     | `OAuth`         | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Tracking
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Postmon](http://postmon.com.br) | An API to query Brazilian ZIP codes and orders easily, quickly and free | No | No | Unknown |
-| [Sweden](https://developer.postnord.com/docs2) | Provides information about parcels in transport | `apiKey` | No | Unknown |
-| [UPS](https://www.ups.com/upsdeveloperkit) | Shipment and Address information | `apiKey` | Yes | Unknown |
-| [WhatPulse](https://whatpulse.org/pages/webapi/) | Small application that measures your keyboard/mouse usage | No | Yes | Unknown |
+
+| API                                              | Description                                                             | Auth     | HTTPS | CORS    |
+| ------------------------------------------------ | ----------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Postmon](http://postmon.com.br)                 | An API to query Brazilian ZIP codes and orders easily, quickly and free | No       | No    | Unknown |
+| [Sweden](https://developer.postnord.com/docs2)   | Provides information about parcels in transport                         | `apiKey` | No    | Unknown |
+| [UPS](https://www.ups.com/upsdeveloperkit)       | Shipment and Address information                                        | `apiKey` | Yes   | Unknown |
+| [WhatPulse](https://whatpulse.org/pages/webapi/) | Small application that measures your keyboard/mouse usage               | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Transportation
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [ADS-B Exchange](https://www.adsbexchange.com/data/) | Access real-time and historical data of any and all airborne aircraft | No | Yes | Unknown |
-| [AIS Hub](http://www.aishub.net/api) | Real-time data of any marine and inland vessel equipped with AIS tracking system | `apiKey` | No | Unknown |
-| [AIS Web](http://www.aisweb.aer.mil.br/api/doc/index.cfm) | Aeronautical information in digital media produced by the Department of Airspace Control (DECEA) | `apiKey` | No | Unknown |
-| [Amadeus Travel Innovation Sandbox](https://sandbox.amadeus.com/) | Travel Search - Limited usage | `apiKey` | Yes | Unknown |
-| [Bay Area Rapid Transit](http://api.bart.gov) | Stations and predicted arrivals for BART | `apiKey` | No | Unknown |
-| [BlaBlaCar](https://dev.blablacar.com) | Search car sharing trips | `apiKey` | Yes | Unknown |
-| [Community Transit](https://github.com/transitland/transitland-datastore/blob/master/README.md#api-endpoints) | Transitland API | No | Yes | Unknown |
-| [Goibibo](https://developer.goibibo.com/docs) | API for travel search | `apiKey` | Yes | Unknown |
-| [GraphHopper](https://graphhopper.com/api/1/docs/) | A-to-B routing with turn-by-turn instructions | `apiKey` | Yes | Unknown |
-| [Icelandic APIs](http://docs.apis.is/) | Open APIs that deliver services in or regarding Iceland | No | Yes | Unknown |
-| [Indian Railways](http://api.erail.in/) | Indian Railways Information | `apiKey` | No | Unknown |
-| [Izi](http://api-docs.izi.travel/) | Audio guide for travellers | `apiKey` | Yes | Unknown |
-| [Metro Lisboa](http://app.metrolisboa.pt/status/getLinhas.php) | Delays in subway lines | No | No | No |
-| [Navitia](https://api.navitia.io/) | The open API for building cool stuff with transport data | `apiKey` | Yes | Unknown |
-| [REFUGE Restrooms](https://www.refugerestrooms.org/api/docs/#!/restrooms) | Provides safe restroom access for transgender, intersex and gender nonconforming individuals | No | Yes | Unknown |
-| [Schiphol Airport](https://developer.schiphol.nl/) | Schiphol | `apiKey` | Yes | Unknown |
-| [TransitLand](https://transit.land/documentation/datastore/api-endpoints.html) | Transit Aggregation | No | Yes | Unknown |
-| [Transport for Atlanta, US](http://www.itsmarta.com/app-developer-resources.aspx) | Marta | No | No | Unknown |
-| [Transport for Auckland, New Zealand](https://api.at.govt.nz/) | Auckland Transport | No | Yes | Unknown |
-| [Transport for Belgium](https://hello.irail.be/api/) | Belgian transport API | No | Yes | Unknown |
-| [Transport for Berlin, Germany](https://github.com/derhuerst/vbb-rest/blob/3/docs/index.md) | Third-party VBB API | No | Yes | Unknown |
-| [Transport for Bordeaux, France](https://opendata.bordeaux-metropole.fr/explore/) | Bordeaux Métropole public transport and more (France) | `apiKey` | Yes | Unknown |
-| [Transport for Boston, US](https://mbta.com/developers/v3-api) | MBTA API | No | No | Unknown |
-| [Transport for Budapest, Hungary](https://bkkfutar.docs.apiary.io) | Budapest public transport API | No | Yes | Unknown |
-| [Transport for Chicago, US](http://www.transitchicago.com/developers/) | CTA | No | No | Unknown |
-| [Transport for Czech Republic](https://www.chaps.cz/eng/products/idos-internet) | Czech transport API | No | Yes | Unknown |
-| [Transport for Denver, US](http://www.rtd-denver.com/gtfs-developer-guide.shtml) | RTD | No | No | Unknown |
-| [Transport for Finland](https://digitransit.fi/en/developers/ ) | Finnish transport API | No | Yes | Unknown |
-| [Transport for Germany](http://data.deutschebahn.com/dataset/api-fahrplan) | Deutsche Bahn (DB) API | `apiKey` | No | Unknown |
-| [Transport for Grenoble, France](https://www.metromobilite.fr/pages/opendata/OpenDataApi.html) | Grenoble public transport | No | No | No |
-| [Transport for Honolulu, US](http://hea.thebus.org/api_info.asp) | Honolulu Transportation Information | `apiKey` | No | Unknown |
-| [Transport for India](https://data.gov.in/sector/transport) | India Public Transport API | `apiKey` | Yes | Unknown |
-| [Transport for Lisbon, Portugal](https://emel.city-platform.com/opendata/) | Data about buses routes, parking and traffic | `apiKey` | Yes | Unknown | 
-| [Transport for London, England](https://api.tfl.gov.uk) | TfL API | No | Yes | Unknown |
-| [Transport for Madrid, Spain](http://opendata.emtmadrid.es/Servicios-web/BUS) | Madrid BUS transport API | `apiKey` | No | Unknown |
-| [Transport for Manchester, England](https://developer.tfgm.com/) | TfGM transport network data | `apiKey` | Yes | No |
-| [Transport for Minneapolis, US](http://svc.metrotransit.org/) | NexTrip API | `OAuth` | No | Unknown |
-| [Transport for New York City, US](http://datamine.mta.info/) | MTA | `apiKey` | No | Unknown |
-| [Transport for Norway](http://reisapi.ruter.no/help) | Norwegian transport API | No | No | Unknown |
-| [Transport for Ottawa, Canada](http://www.octranspo.com/index.php/developers) | OC Transpo next bus arrival API | No | No | Unknown |
-| [Transport for Paris, France](http://restratpws.azurewebsites.net/swagger/) | Live schedules made simple | No | No | Unknown |
-| [Transport for Paris, France](http://data.ratp.fr/api/v1/console/datasets/1.0/search/) | RATP Open Data API | No | No | Unknown |
-| [Transport for Philadelphia, US](http://www3.septa.org/hackathon/) | SEPTA APIs | No | No | Unknown |
-| [Transport for Sao Paulo, Brazil](http://www.sptrans.com.br/desenvolvedores/api-do-olho-vivo-guia-de-referencia/documentacao-api/) | SPTrans | `OAuth` | No | Unknown |
-| [Transport for Sweden](https://www.trafiklab.se/api) | Public Transport consumer | `OAuth` | Yes | Unknown |
-| [Transport for Switzerland](https://opentransportdata.swiss/en/) | Official Swiss Public Transport Open Data | `apiKey` | Yes | Unknown |
-| [Transport for Switzerland](https://transport.opendata.ch/) | Swiss public transport API | No | Yes | Unknown |
-| [Transport for The Netherlands](http://www.ns.nl/reisinformatie/ns-api) | NS, only trains | `apiKey` | No | Unknown |
-| [Transport for The Netherlands](https://github.com/skywave/KV78Turbo-OVAPI/wiki) | OVAPI, country-wide public transport | No | Yes | Unknown |
-| [Transport for Toronto, Canada](https://myttc.ca/developers) | TTC | No | Yes | Unknown |
-| [Transport for United States](http://www.nextbus.com/xmlFeedDocs/NextBusXMLFeed.pdf) | NextBus API | No | No | Unknown |
-| [Transport for Vancouver, Canada](https://developer.translink.ca/) | TransLink | `OAuth` | Yes | Unknown |
-| [Transport for Victoria, AU](https://www.ptv.vic.gov.au/about-ptv/ptv-data-and-reports/digital-products/ptv-timetable-api/) | PTV API | `apiKey` | Yes | Unknown |
-| [Transport for Washington, US](https://developer.wmata.com/) | Washington Metro transport API | `OAuth` | Yes | Unknown |
-| [Uber](https://developer.uber.com/products) | Uber ride requests and price estimation | `OAuth` | Yes | Yes |
-| [WhereIsMyTransport](https://developer.whereismytransport.com/) | Platform for public transport data in emerging cities | `OAuth` | Yes | Unknown |
+
+| API                                                                                                                                | Description                                                                                      | Auth     | HTTPS | CORS    |
+| ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------- | ----- | ------- |
+| [ADS-B Exchange](https://www.adsbexchange.com/data/)                                                                               | Access real-time and historical data of any and all airborne aircraft                            | No       | Yes   | Unknown |
+| [AIS Hub](http://www.aishub.net/api)                                                                                               | Real-time data of any marine and inland vessel equipped with AIS tracking system                 | `apiKey` | No    | Unknown |
+| [AIS Web](http://www.aisweb.aer.mil.br/api/doc/index.cfm)                                                                          | Aeronautical information in digital media produced by the Department of Airspace Control (DECEA) | `apiKey` | No    | Unknown |
+| [Amadeus Travel Innovation Sandbox](https://sandbox.amadeus.com/)                                                                  | Travel Search - Limited usage                                                                    | `apiKey` | Yes   | Unknown |
+| [Bay Area Rapid Transit](http://api.bart.gov)                                                                                      | Stations and predicted arrivals for BART                                                         | `apiKey` | No    | Unknown |
+| [BlaBlaCar](https://dev.blablacar.com)                                                                                             | Search car sharing trips                                                                         | `apiKey` | Yes   | Unknown |
+| [Community Transit](https://github.com/transitland/transitland-datastore/blob/master/README.md#api-endpoints)                      | Transitland API                                                                                  | No       | Yes   | Unknown |
+| [Goibibo](https://developer.goibibo.com/docs)                                                                                      | API for travel search                                                                            | `apiKey` | Yes   | Unknown |
+| [GraphHopper](https://graphhopper.com/api/1/docs/)                                                                                 | A-to-B routing with turn-by-turn instructions                                                    | `apiKey` | Yes   | Unknown |
+| [Icelandic APIs](http://docs.apis.is/)                                                                                             | Open APIs that deliver services in or regarding Iceland                                          | No       | Yes   | Unknown |
+| [Indian Railways](http://api.erail.in/)                                                                                            | Indian Railways Information                                                                      | `apiKey` | No    | Unknown |
+| [Izi](http://api-docs.izi.travel/)                                                                                                 | Audio guide for travellers                                                                       | `apiKey` | Yes   | Unknown |
+| [Metro Lisboa](http://app.metrolisboa.pt/status/getLinhas.php)                                                                     | Delays in subway lines                                                                           | No       | No    | No      |
+| [Navitia](https://api.navitia.io/)                                                                                                 | The open API for building cool stuff with transport data                                         | `apiKey` | Yes   | Unknown |
+| [REFUGE Restrooms](https://www.refugerestrooms.org/api/docs/#!/restrooms)                                                          | Provides safe restroom access for transgender, intersex and gender nonconforming individuals     | No       | Yes   | Unknown |
+| [Schiphol Airport](https://developer.schiphol.nl/)                                                                                 | Schiphol                                                                                         | `apiKey` | Yes   | Unknown |
+| [TransitLand](https://transit.land/documentation/datastore/api-endpoints.html)                                                     | Transit Aggregation                                                                              | No       | Yes   | Unknown |
+| [Transport for Atlanta, US](http://www.itsmarta.com/app-developer-resources.aspx)                                                  | Marta                                                                                            | No       | No    | Unknown |
+| [Transport for Auckland, New Zealand](https://api.at.govt.nz/)                                                                     | Auckland Transport                                                                               | No       | Yes   | Unknown |
+| [Transport for Belgium](https://hello.irail.be/api/)                                                                               | Belgian transport API                                                                            | No       | Yes   | Unknown |
+| [Transport for Berlin, Germany](https://github.com/derhuerst/vbb-rest/blob/3/docs/index.md)                                        | Third-party VBB API                                                                              | No       | Yes   | Unknown |
+| [Transport for Bordeaux, France](https://opendata.bordeaux-metropole.fr/explore/)                                                  | Bordeaux Métropole public transport and more (France)                                            | `apiKey` | Yes   | Unknown |
+| [Transport for Boston, US](https://mbta.com/developers/v3-api)                                                                     | MBTA API                                                                                         | No       | No    | Unknown |
+| [Transport for Budapest, Hungary](https://bkkfutar.docs.apiary.io)                                                                 | Budapest public transport API                                                                    | No       | Yes   | Unknown |
+| [Transport for Chicago, US](http://www.transitchicago.com/developers/)                                                             | CTA                                                                                              | No       | No    | Unknown |
+| [Transport for Czech Republic](https://www.chaps.cz/eng/products/idos-internet)                                                    | Czech transport API                                                                              | No       | Yes   | Unknown |
+| [Transport for Denver, US](http://www.rtd-denver.com/gtfs-developer-guide.shtml)                                                   | RTD                                                                                              | No       | No    | Unknown |
+| [Transport for Finland](https://digitransit.fi/en/developers/)                                                                     | Finnish transport API                                                                            | No       | Yes   | Unknown |
+| [Transport for Germany](http://data.deutschebahn.com/dataset/api-fahrplan)                                                         | Deutsche Bahn (DB) API                                                                           | `apiKey` | No    | Unknown |
+| [Transport for Grenoble, France](https://www.metromobilite.fr/pages/opendata/OpenDataApi.html)                                     | Grenoble public transport                                                                        | No       | No    | No      |
+| [Transport for Honolulu, US](http://hea.thebus.org/api_info.asp)                                                                   | Honolulu Transportation Information                                                              | `apiKey` | No    | Unknown |
+| [Transport for India](https://data.gov.in/sector/transport)                                                                        | India Public Transport API                                                                       | `apiKey` | Yes   | Unknown |
+| [Transport for Lisbon, Portugal](https://emel.city-platform.com/opendata/)                                                         | Data about buses routes, parking and traffic                                                     | `apiKey` | Yes   | Unknown |
+| [Transport for London, England](https://api.tfl.gov.uk)                                                                            | TfL API                                                                                          | No       | Yes   | Unknown |
+| [Transport for Madrid, Spain](http://opendata.emtmadrid.es/Servicios-web/BUS)                                                      | Madrid BUS transport API                                                                         | `apiKey` | No    | Unknown |
+| [Transport for Manchester, England](https://developer.tfgm.com/)                                                                   | TfGM transport network data                                                                      | `apiKey` | Yes   | No      |
+| [Transport for Minneapolis, US](http://svc.metrotransit.org/)                                                                      | NexTrip API                                                                                      | `OAuth`  | No    | Unknown |
+| [Transport for New York City, US](http://datamine.mta.info/)                                                                       | MTA                                                                                              | `apiKey` | No    | Unknown |
+| [Transport for Norway](http://reisapi.ruter.no/help)                                                                               | Norwegian transport API                                                                          | No       | No    | Unknown |
+| [Transport for Ottawa, Canada](http://www.octranspo.com/index.php/developers)                                                      | OC Transpo next bus arrival API                                                                  | No       | No    | Unknown |
+| [Transport for Paris, France](http://restratpws.azurewebsites.net/swagger/)                                                        | Live schedules made simple                                                                       | No       | No    | Unknown |
+| [Transport for Paris, France](http://data.ratp.fr/api/v1/console/datasets/1.0/search/)                                             | RATP Open Data API                                                                               | No       | No    | Unknown |
+| [Transport for Philadelphia, US](http://www3.septa.org/hackathon/)                                                                 | SEPTA APIs                                                                                       | No       | No    | Unknown |
+| [Transport for Sao Paulo, Brazil](http://www.sptrans.com.br/desenvolvedores/api-do-olho-vivo-guia-de-referencia/documentacao-api/) | SPTrans                                                                                          | `OAuth`  | No    | Unknown |
+| [Transport for Sweden](https://www.trafiklab.se/api)                                                                               | Public Transport consumer                                                                        | `OAuth`  | Yes   | Unknown |
+| [Transport for Switzerland](https://opentransportdata.swiss/en/)                                                                   | Official Swiss Public Transport Open Data                                                        | `apiKey` | Yes   | Unknown |
+| [Transport for Switzerland](https://transport.opendata.ch/)                                                                        | Swiss public transport API                                                                       | No       | Yes   | Unknown |
+| [Transport for The Netherlands](http://www.ns.nl/reisinformatie/ns-api)                                                            | NS, only trains                                                                                  | `apiKey` | No    | Unknown |
+| [Transport for The Netherlands](https://github.com/skywave/KV78Turbo-OVAPI/wiki)                                                   | OVAPI, country-wide public transport                                                             | No       | Yes   | Unknown |
+| [Transport for Toronto, Canada](https://myttc.ca/developers)                                                                       | TTC                                                                                              | No       | Yes   | Unknown |
+| [Transport for United States](http://www.nextbus.com/xmlFeedDocs/NextBusXMLFeed.pdf)                                               | NextBus API                                                                                      | No       | No    | Unknown |
+| [Transport for Vancouver, Canada](https://developer.translink.ca/)                                                                 | TransLink                                                                                        | `OAuth`  | Yes   | Unknown |
+| [Transport for Victoria, AU](https://www.ptv.vic.gov.au/about-ptv/ptv-data-and-reports/digital-products/ptv-timetable-api/)        | PTV API                                                                                          | `apiKey` | Yes   | Unknown |
+| [Transport for Washington, US](https://developer.wmata.com/)                                                                       | Washington Metro transport API                                                                   | `OAuth`  | Yes   | Unknown |
+| [Uber](https://developer.uber.com/products)                                                                                        | Uber ride requests and price estimation                                                          | `OAuth`  | Yes   | Yes     |
+| [WhereIsMyTransport](https://developer.whereismytransport.com/)                                                                    | Platform for public transport data in emerging cities                                            | `OAuth`  | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### URL Shorteners
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Bitly](http://dev.bitly.com/get_started.html) | URL shortener and link management | `OAuth` | Yes | Unknown |
-| [CleanURI](https://cleanuri.com/docs) | URL shortener service | `No` | Yes | Yes |
-| [ClickMeter](https://support.clickmeter.com/hc/en-us/categories/201474986) | Monitor, compare and optimize your marketing links | `apiKey` | Yes | Unknown |
-| [Rebrandly](https://developers.rebrandly.com/v1/docs) | Custom URL shortener for sharing branded links | `apiKey` | Yes | Unknown |
-| [Relink](https://rel.ink) | Free and secure URL shortener | No | Yes | Yes |
+
+| API                                                                        | Description                                        | Auth     | HTTPS | CORS    |
+| -------------------------------------------------------------------------- | -------------------------------------------------- | -------- | ----- | ------- |
+| [Bitly](http://dev.bitly.com/get_started.html)                             | URL shortener and link management                  | `OAuth`  | Yes   | Unknown |
+| [CleanURI](https://cleanuri.com/docs)                                      | URL shortener service                              | `No`     | Yes   | Yes     |
+| [ClickMeter](https://support.clickmeter.com/hc/en-us/categories/201474986) | Monitor, compare and optimize your marketing links | `apiKey` | Yes   | Unknown |
+| [Rebrandly](https://developers.rebrandly.com/v1/docs)                      | Custom URL shortener for sharing branded links     | `apiKey` | Yes   | Unknown |
+| [Relink](https://rel.ink)                                                  | Free and secure URL shortener                      | No       | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
+
 ### Vehicle
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Brazilian Vehicles and Prices](https://deividfortuna.github.io/fipe/) | Vehicles information from Fundação Instituto de Pesquisas Econômicas - Fipe | No | Yes | Unknown |
-| [Kelley Blue Book](http://developer.kbb.com/#!/data/1-Default) | Vehicle info, pricing, configuration, plus much more | `apiKey` | Yes | No |
-| [Mercedes-Benz](https://developer.mercedes-benz.com/apis) | Telematics data, remotely access vehicle functions, car configurator, locate service dealers | `apiKey` | Yes | No |
-| [NHTSA](https://vpic.nhtsa.dot.gov/api/) | NHTSA Product Information Catalog and Vehicle Listing | No | Yes | Unknown |
-| [Smartcar](https://smartcar.com/docs/) | Lock and unlock vehicles and get data like odometer reading and location. Works on most new cars | `OAuth` | Yes | Yes |
+
+| API                                                                    | Description                                                                                      | Auth     | HTTPS | CORS    |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------- | ----- | ------- |
+| [Brazilian Vehicles and Prices](https://deividfortuna.github.io/fipe/) | Vehicles information from Fundação Instituto de Pesquisas Econômicas - Fipe                      | No       | Yes   | Unknown |
+| [Kelley Blue Book](http://developer.kbb.com/#!/data/1-Default)         | Vehicle info, pricing, configuration, plus much more                                             | `apiKey` | Yes   | No      |
+| [Mercedes-Benz](https://developer.mercedes-benz.com/apis)              | Telematics data, remotely access vehicle functions, car configurator, locate service dealers     | `apiKey` | Yes   | No      |
+| [NHTSA](https://vpic.nhtsa.dot.gov/api/)                               | NHTSA Product Information Catalog and Vehicle Listing                                            | No       | Yes   | Unknown |
+| [Smartcar](https://smartcar.com/docs/)                                 | Lock and unlock vehicles and get data like odometer reading and location. Works on most new cars | `OAuth`  | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
+
 ### Video
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [An API of Ice And Fire](https://anapioficeandfire.com/) | Game Of Thrones API | No | Yes | Unknown |
-| [Breaking Bad](https://breakingbadapi.com/documentation) | Breaking Bad API | No | Yes | Unknown |
-| [Breaking Bad Quotes](https://github.com/shevabam/breaking-bad-quotes) | Some Breaking Bad quotes | No | Yes | Unknown |
-| [Czech Television](http://www.ceskatelevize.cz/xml/tv-program/) | TV programme of Czech TV | No | No | Unknown |
-| [Dailymotion](https://developer.dailymotion.com/) | Dailymotion Developer API | `OAuth` | Yes | Unknown |
-| [Harry Potter](https://www.potterapi.com/) | Harry Potter API | `apiKey` | Yes | Yes |
-| [Open Movie Database](http://www.omdbapi.com/) | Movie information | `apiKey` | Yes | Unknown |
-| [Ron Swanson Quotes](https://github.com/jamesseanwright/ron-swanson-quotes#ron-swanson-quotes-api) | Television | No | Yes | Unknown |
-| [Shotstack](https://shotstack.io/product/video-editing-api/) | A cloud-based video editing API to build scalable video-first applications and automation workflows | `apiKey` | Yes | Unknown |
-| [STAPI](http://stapi.co) | Information on all things Star Trek | No | No | No |
-| [SWAPI](https://swapi.co) | Star Wars Information | No | Yes | Unknown |
-| [The Lord of the Rings](https://the-one-api.herokuapp.com/) | The Lord of the Rings API | `apiKey` | Yes | Unknown |
-| [TMDb](https://www.themoviedb.org/documentation/api) | Community-based movie data | `apiKey` | Yes | Unknown |
-| [Trakt](https://trakt.tv/b/api-docs) | Movie and TV Data | `apiKey` | Yes | Yes |
-| [TVDB](https://api.thetvdb.com/swagger) | Television data | `apiKey` | Yes | Unknown |
-| [TVMaze](http://www.tvmaze.com/api) | TV Show Data | No | No | Unknown |
-| [Utelly](https://market.mashape.com/utelly/utelly) | Check where a tv show or movie is available | `X-Mashape-Key` | Yes | Unknown |
-| [Vimeo](https://developer.vimeo.com/) | Vimeo Developer API | `OAuth` | Yes | Unknown |
-| [YouTube](https://developers.google.com/youtube/) | Add YouTube functionality to your sites and apps | `OAuth` | Yes | Unknown |
+
+| API                                                                                                | Description                                                                                         | Auth            | HTTPS | CORS    |
+| -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | --------------- | ----- | ------- |
+| [An API of Ice And Fire](https://anapioficeandfire.com/)                                           | Game Of Thrones API                                                                                 | No              | Yes   | Unknown |
+| [Breaking Bad](https://breakingbadapi.com/documentation)                                           | Breaking Bad API                                                                                    | No              | Yes   | Unknown |
+| [Breaking Bad Quotes](https://github.com/shevabam/breaking-bad-quotes)                             | Some Breaking Bad quotes                                                                            | No              | Yes   | Unknown |
+| [Czech Television](http://www.ceskatelevize.cz/xml/tv-program/)                                    | TV programme of Czech TV                                                                            | No              | No    | Unknown |
+| [Dailymotion](https://developer.dailymotion.com/)                                                  | Dailymotion Developer API                                                                           | `OAuth`         | Yes   | Unknown |
+| [Harry Potter](https://www.potterapi.com/)                                                         | Harry Potter API                                                                                    | `apiKey`        | Yes   | Yes     |
+| [Open Movie Database](http://www.omdbapi.com/)                                                     | Movie information                                                                                   | `apiKey`        | Yes   | Unknown |
+| [Ron Swanson Quotes](https://github.com/jamesseanwright/ron-swanson-quotes#ron-swanson-quotes-api) | Television                                                                                          | No              | Yes   | Unknown |
+| [Shotstack](https://shotstack.io/product/video-editing-api/)                                       | A cloud-based video editing API to build scalable video-first applications and automation workflows | `apiKey`        | Yes   | Unknown |
+| [STAPI](http://stapi.co)                                                                           | Information on all things Star Trek                                                                 | No              | No    | No      |
+| [SWAPI](https://swapi.co)                                                                          | Star Wars Information                                                                               | No              | Yes   | Unknown |
+| [The Lord of the Rings](https://the-one-api.herokuapp.com/)                                        | The Lord of the Rings API                                                                           | `apiKey`        | Yes   | Unknown |
+| [TMDb](https://www.themoviedb.org/documentation/api)                                               | Community-based movie data                                                                          | `apiKey`        | Yes   | Unknown |
+| [Trakt](https://trakt.tv/b/api-docs)                                                               | Movie and TV Data                                                                                   | `apiKey`        | Yes   | Yes     |
+| [TVDB](https://api.thetvdb.com/swagger)                                                            | Television data                                                                                     | `apiKey`        | Yes   | Unknown |
+| [TVMaze](http://www.tvmaze.com/api)                                                                | TV Show Data                                                                                        | No              | No    | Unknown |
+| [Utelly](https://market.mashape.com/utelly/utelly)                                                 | Check where a tv show or movie is available                                                         | `X-Mashape-Key` | Yes   | Unknown |
+| [Vimeo](https://developer.vimeo.com/)                                                              | Vimeo Developer API                                                                                 | `OAuth`         | Yes   | Unknown |
+| [YouTube](https://developers.google.com/youtube/)                                                  | Add YouTube functionality to your sites and apps                                                    | `OAuth`         | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
+
 ### Weather
-API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [7Timer!](http://www.7timer.info/doc.php?lang=en) | Weather, especially for Astroweather | No | No | Unknown |
-| [APIXU](https://www.apixu.com/doc/request.aspx) | Weather | `apiKey` | Yes | Unknown |
-| [Dark Sky](https://darksky.net/dev/) | Weather | `apiKey` | Yes | No |
-| [MetaWeather](https://www.metaweather.com/api/) | Weather | No | Yes | No |
-| [Meteorologisk Institutt](https://api.met.no/weatherapi/documentation) | Weather and climate data | No | Yes | Unknown |
-| [NOAA Climate Data](https://www.ncdc.noaa.gov/cdo-web/) | Weather and climate data | `apiKey` | Yes | Unknown |
-| [ODWeather](http://api.oceandrivers.com/static/docs.html) | Weather and weather webcams | No | No | Unknown |
-| [OpenUV](https://www.openuv.io) | Real-time UV Index Forecast | `apiKey` | Yes | Unknown |
-| [OpenWeatherMap](http://openweathermap.org/api) | Weather | `apiKey` | No | Unknown |
-| [Storm Glass](https://stormglass.io/) | Global marine weather from multiple sources | `apiKey` | Yes | Yes |
-| [Weatherbit](https://www.weatherbit.io/api) | Weather | `apiKey` | Yes | Unknown |
-| [Yahoo! Weather](https://developer.yahoo.com/weather/) | Weather | `apiKey` | Yes | Unknown |
+
+| API                                                                    | Description                                 | Auth     | HTTPS | CORS    |
+| ---------------------------------------------------------------------- | ------------------------------------------- | -------- | ----- | ------- |
+| [7Timer!](http://www.7timer.info/doc.php?lang=en)                      | Weather, especially for Astroweather        | No       | No    | Unknown |
+| [APIXU](https://www.apixu.com/doc/request.aspx)                        | Weather                                     | `apiKey` | Yes   | Unknown |
+| [Dark Sky](https://darksky.net/dev/)                                   | Weather                                     | `apiKey` | Yes   | No      |
+| [MetaWeather](https://www.metaweather.com/api/)                        | Weather                                     | No       | Yes   | No      |
+| [Meteorologisk Institutt](https://api.met.no/weatherapi/documentation) | Weather and climate data                    | No       | Yes   | Unknown |
+| [NOAA Climate Data](https://www.ncdc.noaa.gov/cdo-web/)                | Weather and climate data                    | `apiKey` | Yes   | Unknown |
+| [ODWeather](http://api.oceandrivers.com/static/docs.html)              | Weather and weather webcams                 | No       | No    | Unknown |
+| [OpenUV](https://www.openuv.io)                                        | Real-time UV Index Forecast                 | `apiKey` | Yes   | Unknown |
+| [OpenWeatherMap](http://openweathermap.org/api)                        | Weather                                     | `apiKey` | No    | Unknown |
+| [Storm Glass](https://stormglass.io/)                                  | Global marine weather from multiple sources | `apiKey` | Yes   | Yes     |
+| [Weatherbit](https://www.weatherbit.io/api)                            | Weather                                     | `apiKey` | Yes   | Unknown |
+| [Yahoo! Weather](https://developer.yahoo.com/weather/)                 | Weather                                     | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Here is the official notice from 2021:

https://github.blog/changelog/2021-04-19-deprecation-notice-github-jobs-site/

